### PR TITLE
ci: 补齐跨平台 CI，并修复 Windows 下的测试兼容性

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,16 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    name: Smoke verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
     steps:
       - name: Checkout code
@@ -33,8 +41,65 @@ jobs:
       - name: Run TypeScript checks
         run: npm run typecheck
 
+      - name: Run app build smoke test
+        run: npm run build:app
+
+  test:
+    name: Vitest (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Use Node.js 22.22.1
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.22.1'
+
+      - name: Show tool versions
+        run: |
+          node -v
+          npm -v
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Run full Vitest suite
         run: npm test
+
+  model-regression:
+    name: Model regression (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - verify
+      - test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Use Node.js 22.22.1
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.22.1'
+
+      - name: Show tool versions
+        run: |
+          node -v
+          npm -v
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Run model regression suite
         run: npm run test:model-regression -- --skip-typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,12 @@ jobs:
         run: npm install
 
       - name: Run full Vitest suite
+        if: matrix.os != 'windows-latest'
         run: npm test
+
+      - name: Run full Vitest suite
+        if: matrix.os == 'windows-latest'
+        run: npm test -- --minWorkers=1 --maxWorkers=1
 
   model-regression:
     name: Model regression (ubuntu-latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - windows-latest
           - ubuntu-latest
           - macos-latest
 

--- a/electron/main/__tests__/cli-run-direct-permission.test.ts
+++ b/electron/main/__tests__/cli-run-direct-permission.test.ts
@@ -5,7 +5,7 @@ const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 function extractRunDirectSource(cliSource: string): string {
   const matched = cliSource.match(
-    /export async function runDirect\([\s\S]*?\n}\n\nfunction buildCommandCapabilityEnv\(\): NodeJS\.ProcessEnv \{/
+    /export async function runDirect\([\s\S]*?\r?\n}\r?\n\r?\nfunction buildCommandCapabilityEnv\(\): NodeJS\.ProcessEnv \{/
   )
   if (!matched) {
     throw new Error('runDirect source block not found')

--- a/electron/main/__tests__/feishu-official-plugin-state.test.ts
+++ b/electron/main/__tests__/feishu-official-plugin-state.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 const {
   applyConfigPatchGuardedMock,
@@ -224,7 +225,7 @@ describe('getFeishuOfficialPluginState', () => {
         expect.objectContaining({
           source: 'npm',
           spec: '@larksuite/openclaw-lark',
-          installPath: '/Users/alice/.openclaw/extensions/openclaw-lark',
+          installPath: path.join('/Users/alice/.openclaw', 'extensions', 'openclaw-lark'),
         })
       )
       expect(result.normalizedConfig.session.dmScope).toBe('per-account-channel-peer')

--- a/electron/main/__tests__/gateway-lifecycle-controller.test.ts
+++ b/electron/main/__tests__/gateway-lifecycle-controller.test.ts
@@ -40,7 +40,7 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
-async function waitForCalls(mock: ReturnType<typeof vi.fn>, expectedCalls: number, timeoutMs = 200): Promise<void> {
+async function waitForCalls(mock: ReturnType<typeof vi.fn>, expectedCalls: number, timeoutMs = 1000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (mock.mock.calls.length >= expectedCalls) {

--- a/electron/main/__tests__/local-model-probe.test.ts
+++ b/electron/main/__tests__/local-model-probe.test.ts
@@ -343,7 +343,13 @@ describe('repairMainAuthProfilesFromOtherAgentStores', () => {
 describe('repairAgentAuthProfilesFromOtherAgentStores', () => {
   it('copies minimax-portal oauth auth when repair is requested for canonical minimax', async () => {
     const channelDefaultAuthStorePath = '/tmp/openclaw/profiles/team-a/agents/channel-default/agent/auth-profiles.json'
-    const channelBotAuthStorePath = '/tmp/openclaw/profiles/team-a/agents/channel-bot/agent/auth-profiles.json'
+    const channelBotAuthStorePath = path.join(
+      '/tmp/openclaw/profiles/team-a',
+      'agents',
+      'channel-bot',
+      'agent',
+      'auth-profiles.json'
+    )
     let writeCount = 0
     let writtenPath = ''
     const written = { value: null as Record<string, any> | null }
@@ -464,7 +470,13 @@ describe('repairAgentAuthProfilesFromOtherAgentStores', () => {
 
   it('keeps non-minimax provider repair exact and does not pull sibling aliases', async () => {
     const channelDefaultAuthStorePath = '/tmp/openclaw/profiles/team-a/agents/channel-default/agent/auth-profiles.json'
-    const channelBotAuthStorePath = '/tmp/openclaw/profiles/team-a/agents/channel-bot/agent/auth-profiles.json'
+    const channelBotAuthStorePath = path.join(
+      '/tmp/openclaw/profiles/team-a',
+      'agents',
+      'channel-bot',
+      'agent',
+      'auth-profiles.json'
+    )
     const writeJsonSpy = vi.fn(async () => undefined)
 
     const readFileSpy = vi.fn(async (filePath: unknown) => {

--- a/electron/main/__tests__/openclaw-auth-registry.test.ts
+++ b/electron/main/__tests__/openclaw-auth-registry.test.ts
@@ -30,6 +30,31 @@ function findDistFile(root: string, prefix: string): string {
   return path.join(distDir, matched)
 }
 
+function resolveLineBreakSeparator(text: string): string {
+  return text.match(/\r?\n\r?\n/)?.[0] || '\n\n'
+}
+
+function replaceFixtureBlock(
+  text: string,
+  marker: string,
+  replacement: string
+): string {
+  const separator = resolveLineBreakSeparator(text)
+  return text.replace(
+    marker.replaceAll('\n\n', separator),
+    replacement.replaceAll('\n\n', separator)
+  )
+}
+
+function replaceFixturePattern(
+  text: string,
+  pattern: RegExp,
+  replacement: string
+): string {
+  const separator = resolveLineBreakSeparator(text)
+  return text.replace(pattern, replacement.replaceAll('\n\n', separator))
+}
+
 function addUnsupportedAuthChoiceVariant(
   root: string,
   input: {
@@ -44,15 +69,15 @@ function addUnsupportedAuthChoiceVariant(
 ) {
   const optionsPath = findDistFile(root, 'auth-choice-options')
   const optionsText = fs.readFileSync(optionsPath, 'utf8')
-  const nextOptionsText = optionsText
-    .replace(
+  const nextOptionsText = replaceFixtureBlock(
+    replaceFixtureBlock(
+      optionsText,
       '];\n\nconst PROVIDER_AUTH_CHOICE_OPTION_HINTS = {',
       `,\n  {\n    value: "${input.providerId}",\n    label: "${input.providerLabel}",\n    hint: "${input.providerHint}",\n    choices: ["${input.authChoice}"]\n  }\n];\n\nconst PROVIDER_AUTH_CHOICE_OPTION_HINTS = {`
-    )
-    .replace(
-      '];\n\nfunction formatAuthChoiceChoicesForCli(params) {',
-      `,\n  {\n    value: "${input.authChoice}",\n    label: "${input.optionLabel}"\n  }\n];\n\nfunction formatAuthChoiceChoicesForCli(params) {`
-    )
+    ),
+    '];\n\nfunction formatAuthChoiceChoicesForCli(params) {',
+    `,\n  {\n    value: "${input.authChoice}",\n    label: "${input.optionLabel}"\n  }\n];\n\nfunction formatAuthChoiceChoicesForCli(params) {`
+  )
 
   if (nextOptionsText === optionsText) {
     throw new Error('Failed to patch auth-choice-options fixture text')
@@ -68,7 +93,8 @@ function addUnsupportedAuthChoiceVariant(
 
   const authChoicePath = findDistFile(root, 'auth-choice')
   const authChoiceText = fs.readFileSync(authChoicePath, 'utf8')
-  const nextAuthChoiceText = authChoiceText.replace(
+  const nextAuthChoiceText = replaceFixtureBlock(
+    authChoiceText,
     '};\n\nfunction resolvePreferredProviderForAuthChoice(choice) {',
     `,\n  "${input.authChoice}": "${input.providerId}"\n};\n\nfunction resolvePreferredProviderForAuthChoice(choice) {`
   )
@@ -98,8 +124,9 @@ function addProviderScopedOnboardApiKeyFlag(
   const flagsPath = findDistFile(root, 'onboard-provider-auth-flags')
   const flagsText = fs.readFileSync(flagsPath, 'utf8')
   const optionKey = `${input.providerId}ApiKey`
-  const nextFlagsText = flagsText.replace(
-    '];\nexport { AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI as n, ONBOARD_PROVIDER_AUTH_FLAGS as t };',
+  const nextFlagsText = replaceFixturePattern(
+    flagsText,
+    /\];\r?\nexport \{ AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI as n, ONBOARD_PROVIDER_AUTH_FLAGS as t \};/,
     `,\n  {\n    optionKey: "${optionKey}",\n    authChoice: "${input.authChoice}",\n    cliFlag: "${input.cliFlag}",\n    cliOption: "${input.cliFlag} <key>",\n    description: "${input.description}"\n  }\n];\nexport { AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI as n, ONBOARD_PROVIDER_AUTH_FLAGS as t };`
   )
   if (nextFlagsText === flagsText) {
@@ -111,7 +138,8 @@ function addProviderScopedOnboardApiKeyFlag(
   const authChoiceText = fs.readFileSync(authChoicePath, 'utf8')
   if (authChoiceText.includes(`"${input.authChoice}":`)) return
 
-  const nextAuthChoiceText = authChoiceText.replace(
+  const nextAuthChoiceText = replaceFixtureBlock(
+    authChoiceText,
     '};\n\nfunction resolvePreferredProviderForAuthChoice(choice) {',
     `,\n  "${input.authChoice}": "${input.providerId}"\n};\n\nfunction resolvePreferredProviderForAuthChoice(choice) {`
   )

--- a/electron/main/__tests__/openclaw-config-coordinator.test.ts
+++ b/electron/main/__tests__/openclaw-config-coordinator.test.ts
@@ -30,7 +30,7 @@ function createDeferred<T>() {
   return { promise, resolve }
 }
 
-async function waitForGuardedWriteCalls(expectedCalls: number, timeoutMs = 200): Promise<void> {
+async function waitForGuardedWriteCalls(expectedCalls: number, timeoutMs = 1000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (guardedWriteConfigMock.mock.calls.length >= expectedCalls) {

--- a/electron/main/__tests__/openclaw-elevated-lifecycle-transaction.test.ts
+++ b/electron/main/__tests__/openclaw-elevated-lifecycle-transaction.test.ts
@@ -30,7 +30,7 @@ describe('openclaw-elevated-lifecycle-transaction', () => {
     expect(snapshot.fallbackStateRootUsed).toBe(false)
     expect(snapshot.targets.map((target) => target.path)).toEqual([
       '/Users/test/Library/Application Support/OpenClaw/profiles/main',
-      '/Users/test/.npm',
+      path.join('/Users/test', '.npm'),
     ])
     expect(snapshot.targets.every((target) => target.createIfMissing === false)).toBe(true)
   })

--- a/electron/main/__tests__/openclaw-install-discovery.test.ts
+++ b/electron/main/__tests__/openclaw-install-discovery.test.ts
@@ -102,6 +102,7 @@ describe('discoverOpenClawInstallations', () => {
   const tempDirs: string[] = []
   const originalUserDataDir = process.env.QCLAW_USER_DATA_DIR
   const originalHome = process.env.HOME
+  const originalUserProfile = process.env.USERPROFILE
 
   function makeTempDir(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qclaw-openclaw-discovery-'))
@@ -125,6 +126,11 @@ describe('discoverOpenClawInstallations', () => {
       delete process.env.HOME
     } else {
       process.env.HOME = originalHome
+    }
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE
+    } else {
+      process.env.USERPROFILE = originalUserProfile
     }
 
     while (tempDirs.length > 0) {
@@ -302,6 +308,7 @@ describe('discoverOpenClawInstallations', () => {
   it('reports history-only when only historical state files exist', async () => {
     const homeDir = makeTempDir()
     process.env.HOME = homeDir
+    process.env.USERPROFILE = homeDir
 
     const openClawHome = path.join(homeDir, '.openclaw')
     fs.mkdirSync(openClawHome, { recursive: true })
@@ -318,7 +325,7 @@ describe('discoverOpenClawInstallations', () => {
     expect(result.historyDataCandidates).toEqual([
       {
         path: openClawHome,
-        displayPath: '~/.openclaw',
+        displayPath: process.platform === 'win32' ? '~\\.openclaw' : '~/.openclaw',
         reason: 'default-home-dir',
       },
     ])

--- a/electron/main/__tests__/openclaw-npm-runtime.test.ts
+++ b/electron/main/__tests__/openclaw-npm-runtime.test.ts
@@ -5,7 +5,8 @@ import {
 } from '../openclaw-npm-runtime'
 const { mkdtemp, readFile } = process.getBuiltinModule('node:fs/promises') as typeof import('node:fs/promises')
 const { tmpdir } = process.getBuiltinModule('node:os') as typeof import('node:os')
-const { join } = process.getBuiltinModule('node:path') as typeof import('node:path')
+const path = process.getBuiltinModule('node:path') as typeof import('node:path')
+const { join } = path
 
 describe('openclaw-npm-runtime', () => {
   it('creates managed npm runtime files and returns stable command options', async () => {
@@ -19,7 +20,7 @@ describe('openclaw-npm-runtime', () => {
     expect(runtime.userConfigPath).toContain('openclaw-installer')
     expect(runtime.globalConfigPath).toContain('openclaw-installer')
     expect(runtime.cachePath).toContain('openclaw-installer')
-    expect(runtime.cachePath).toContain('/cache/run-')
+    expect(runtime.cachePath).toContain(`${path.sep}cache${path.sep}run-`)
     expect(runtime.commandOptions.fetchTimeoutMs).toBe(20000)
     expect(runtime.commandOptions.fetchRetries).toBe(1)
     expect(runtime.commandOptions.noAudit).toBe(true)
@@ -45,8 +46,8 @@ describe('openclaw-npm-runtime', () => {
     expect(first.userConfigPath).toBe(second.userConfigPath)
     expect(first.globalConfigPath).toBe(second.globalConfigPath)
     expect(first.cachePath).not.toBe(second.cachePath)
-    expect(first.cachePath).toContain('/cache/run-')
-    expect(second.cachePath).toContain('/cache/run-')
+    expect(first.cachePath).toContain(`${path.sep}cache${path.sep}run-`)
+    expect(second.cachePath).toContain(`${path.sep}cache${path.sep}run-`)
   })
 
   it('creates isolated admin cache options outside the managed runtime root', () => {
@@ -62,6 +63,7 @@ describe('openclaw-npm-runtime', () => {
         noFund: true,
       },
       {
+        platform: 'darwin',
         tempDir: '/private/tmp',
         uuidFactory: () => 'admin-run',
       }

--- a/electron/main/__tests__/openclaw-package.test.ts
+++ b/electron/main/__tests__/openclaw-package.test.ts
@@ -20,6 +20,43 @@ function makeTempDir(): string {
   return dir
 }
 
+function buildComparablePathVariants(targetPath: string): Set<string> {
+  const variants = new Set<string>()
+  const normalizedInput = String(targetPath || '').trim()
+  if (!normalizedInput) return variants
+
+  const addVariant = (value: string) => {
+    const normalized = path.normalize(String(value || '').trim())
+    if (!normalized) return
+    variants.add(process.platform === 'win32' ? normalized.toLowerCase() : normalized)
+  }
+
+  addVariant(path.resolve(normalizedInput))
+
+  try {
+    addVariant(fs.realpathSync(normalizedInput))
+  } catch {
+    // Ignore resolution failures and keep the remaining variants.
+  }
+
+  if (typeof fs.realpathSync.native === 'function') {
+    try {
+      addVariant(fs.realpathSync.native(normalizedInput))
+    } catch {
+      // Ignore native resolution failures and keep the remaining variants.
+    }
+  }
+
+  return variants
+}
+
+function expectSameResolvedLocation(actualPath: string, expectedPath: string): void {
+  const actualVariants = buildComparablePathVariants(actualPath)
+  const expectedVariants = buildComparablePathVariants(expectedPath)
+  const sharedVariant = Array.from(actualVariants).find((candidate) => expectedVariants.has(candidate))
+  expect(sharedVariant).toBeDefined()
+}
+
 function createFakeOpenClawInstall(): {
   tempDir: string
   commandPath: string
@@ -200,7 +237,7 @@ describe('resolveOpenClawPackageRoot', () => {
       binaryPath: install.commandPath,
     })
 
-    expect(packageRoot).toBe(fs.realpathSync(install.packageRoot))
+    expectSameResolvedLocation(packageRoot, install.packageRoot)
   })
 
   it('walks parent directories when the resolved binary lives under a package bin subdirectory', async () => {
@@ -210,7 +247,7 @@ describe('resolveOpenClawPackageRoot', () => {
       binaryPath: install.commandPath,
     })
 
-    expect(packageRoot).toBe(fs.realpathSync(install.packageRoot))
+    expectSameResolvedLocation(packageRoot, install.packageRoot)
   })
 
   it('rejects malformed layouts that do not contain an adjacent openclaw package.json', async () => {
@@ -234,16 +271,11 @@ describe('readOpenClawPackageInfo', () => {
       binaryPath: install.commandPath,
     })
 
-    const resolvedPackageRoot = fs.realpathSync(install.packageRoot)
-    const resolvedPackageJsonPath = fs.realpathSync(install.packageJsonPath)
-
-    expect(info).toMatchObject({
-      name: 'openclaw',
-      version: '2026.3.8',
-      packageRoot: resolvedPackageRoot,
-      packageJsonPath: resolvedPackageJsonPath,
-      binaryPath: install.commandPath,
-      resolvedBinaryPath: path.join(resolvedPackageRoot, 'openclaw.mjs'),
-    })
+    expect(info.name).toBe('openclaw')
+    expect(info.version).toBe('2026.3.8')
+    expect(info.binaryPath).toBe(install.commandPath)
+    expectSameResolvedLocation(info.packageRoot, install.packageRoot)
+    expectSameResolvedLocation(info.packageJsonPath, install.packageJsonPath)
+    expectSameResolvedLocation(info.resolvedBinaryPath, path.join(install.packageRoot, 'openclaw.mjs'))
   })
 })

--- a/electron/main/__tests__/openclaw-package.test.ts
+++ b/electron/main/__tests__/openclaw-package.test.ts
@@ -164,10 +164,9 @@ describe('resolveOpenClawBinaryPath', () => {
       env: buildTestEnv({
         HOME: '/Users/alice',
       }),
-      fileExists: (candidate: string) => candidate === install.commandPath,
     })
 
-    expect(resolved).toBe(install.commandPath)
+    expect(resolved.replaceAll('/', path.sep)).toBe(install.commandPath)
   })
 })
 

--- a/electron/main/__tests__/openclaw-paths.test.ts
+++ b/electron/main/__tests__/openclaw-paths.test.ts
@@ -35,7 +35,7 @@ describe('resolveOpenClawPaths', () => {
 
 describe('formatDisplayPath', () => {
   it('converts absolute paths under the user home into display-safe ~/ paths', () => {
-    expect(formatDisplayPath('/Users/alice/.openclaw/openclaw.json', '/Users/alice')).toBe(
+    expect(formatDisplayPath('/Users/alice/.openclaw/openclaw.json', '/Users/alice', 'darwin')).toBe(
       '~/.openclaw/openclaw.json'
     )
   })

--- a/electron/main/__tests__/openclaw-restore-service.test.ts
+++ b/electron/main/__tests__/openclaw-restore-service.test.ts
@@ -294,7 +294,9 @@ describe('openclaw restore service', () => {
     await expect(fs.readFile(path.join(targetStateRoot, 'openclaw.json'), 'utf8')).resolves.toContain('"primary": "openai/gpt-5"')
     await expect(fs.readFile(path.join(targetStateRoot, 'openclaw.json'), 'utf8')).resolves.not.toContain('"defaultModel"')
     await expect(fs.readFile(path.join(wrongStateRoot, 'openclaw.json'), 'utf8')).resolves.toContain('wrong-target')
-    expect((await fs.stat(path.join(targetStateRoot, 'openclaw.json'))).mode & 0o777).toBe(0o600)
+    expect((await fs.stat(path.join(targetStateRoot, 'openclaw.json'))).mode & 0o777).toBe(
+      process.platform === 'win32' ? 0o666 : 0o600
+    )
     expect(createManagedBackupArchiveMock).toHaveBeenCalledWith({
       candidate: expect.objectContaining({
         stateRoot: targetStateRoot,

--- a/electron/main/__tests__/openclaw-skills.test.ts
+++ b/electron/main/__tests__/openclaw-skills.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeOpenClawSkillsPayload,
   normalizeSkillConfigKey,
 } from '../openclaw-skills'
+const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 describe('openclaw skills compatibility helpers', () => {
   it('derives skill metadata from metadata.openclaw when top-level fields are missing', () => {
@@ -43,21 +44,26 @@ describe('openclaw skills compatibility helpers', () => {
   })
 
   it('normalizes list payloads and keeps derived location fields', () => {
-    const payload = normalizeOpenClawSkillsPayload({
-      workspaceDir: '/Users/demo/.openclaw/workspace-default',
-      managedSkillsDir: '/Users/demo/.openclaw/skills',
-      skills: [
-        {
-          name: 'Token Optimizer',
-          source: 'openclaw-workspace',
-          metadata: {
-            openclaw: {
-              skillKey: 'token-optimizer',
+    const payload = normalizeOpenClawSkillsPayload(
+      {
+        workspaceDir: '/Users/demo/.openclaw/workspace-default',
+        managedSkillsDir: '/Users/demo/.openclaw/skills',
+        skills: [
+          {
+            name: 'Token Optimizer',
+            source: 'openclaw-workspace',
+            metadata: {
+              openclaw: {
+                skillKey: 'token-optimizer',
+              },
             },
           },
-        },
-      ],
-    })
+        ],
+      },
+      {
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }
+    )
 
     expect(payload).toMatchObject({
       workspaceDir: '/Users/demo/.openclaw/workspace-default',

--- a/electron/main/__tests__/openclaw-upgrade-service.test.ts
+++ b/electron/main/__tests__/openclaw-upgrade-service.test.ts
@@ -400,7 +400,7 @@ describe('openclaw upgrade service', () => {
     expect(runShellMock).toHaveBeenCalledTimes(1)
     expect(runShellMock).toHaveBeenNthCalledWith(
       1,
-      'npm',
+      process.platform === 'win32' ? 'npm.cmd' : 'npm',
       expect.arrayContaining([
         'install',
         '-g',

--- a/electron/main/__tests__/plugin-install-safety.test.ts
+++ b/electron/main/__tests__/plugin-install-safety.test.ts
@@ -114,7 +114,7 @@ describe('reconcileIncompatibleExtensionPlugins', () => {
         installs: {},
       },
     })
-  })
+  }, 15000)
 
   it('ignores plugins that do not reference the host plugin sdk', async () => {
     const homeDir = await createTempHome()

--- a/electron/main/__tests__/plugin-install-safety.test.ts
+++ b/electron/main/__tests__/plugin-install-safety.test.ts
@@ -114,7 +114,7 @@ describe('reconcileIncompatibleExtensionPlugins', () => {
         installs: {},
       },
     })
-  }, 15000)
+  }, 30000)
 
   it('ignores plugins that do not reference the host plugin sdk', async () => {
     const homeDir = await createTempHome()

--- a/electron/main/__tests__/skills-paths.test.ts
+++ b/electron/main/__tests__/skills-paths.test.ts
@@ -11,10 +11,15 @@ const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 describe('skills paths helpers', () => {
   it('derives managed/workspace locations from skills list payload', () => {
-    const locations = resolveOpenClawSkillLocations({
-      workspaceDir: '/Users/demo/.openclaw/workspace-feishu-default',
-      managedSkillsDir: '/Users/demo/.openclaw/skills',
-    })
+    const locations = resolveOpenClawSkillLocations(
+      {
+        workspaceDir: '/Users/demo/.openclaw/workspace-feishu-default',
+        managedSkillsDir: '/Users/demo/.openclaw/skills',
+      },
+      {
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }
+    )
 
     expect(locations).toEqual({
       workspaceDir: '/Users/demo/.openclaw/workspace-feishu-default',
@@ -26,7 +31,10 @@ describe('skills paths helpers', () => {
   })
 
   it('falls back to ~/.openclaw paths when payload is incomplete', () => {
-    const locations = resolveOpenClawSkillLocations({}, { homeDir: '/Users/fallback' })
+    const locations = resolveOpenClawSkillLocations({}, {
+      homeDir: '/Users/fallback',
+      pathModule: path.posix as unknown as typeof import('node:path'),
+    })
 
     expect(locations).toEqual({
       workspaceDir: '/Users/fallback/.openclaw/workspace',
@@ -65,7 +73,10 @@ describe('skills paths helpers', () => {
         managedSkillsDir: '/Users/demo/.openclaw/skills',
         skills: [{ name: 'token-optimizer' }],
       },
-      { homeDir: '/Users/demo' }
+      {
+        homeDir: '/Users/demo',
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }
     )
 
     expect(payload).toMatchObject({
@@ -84,7 +95,10 @@ describe('skills paths helpers', () => {
         workspaceDir: '/Users/demo/.openclaw/workspace-feishu-default',
         managedSkillsDir: '/Users/demo/.openclaw/skills',
       },
-      { homeDir: '/Users/demo' }
+      {
+        homeDir: '/Users/demo',
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }
     )
 
     expect(buildClawHubInstallArgs('token-optimizer', locations)).toEqual([
@@ -110,6 +124,10 @@ describe('skills paths helpers', () => {
       '--yes',
     ])
 
-    expect(resolveClawHubLockFilePath(locations)).toBe('/Users/demo/.openclaw/.clawhub/lock.json')
+    expect(
+      resolveClawHubLockFilePath(locations, {
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      })
+    ).toBe('/Users/demo/.openclaw/.clawhub/lock.json')
   })
 })

--- a/electron/main/__tests__/skills-uninstall-safety.test.ts
+++ b/electron/main/__tests__/skills-uninstall-safety.test.ts
@@ -6,6 +6,7 @@ import {
   resolveManagedSkillFallbackPath,
   resolveSkillPathUnderRoot,
 } from '../skills-uninstall-safety'
+const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 describe('skills uninstall safety', () => {
   const homeDir = '/Users/demo'
@@ -26,6 +27,7 @@ describe('skills uninstall safety', () => {
   it('resolves fallback path only under managed skills root', () => {
     const result = resolveManagedSkillFallbackPath('/Users/demo/.openclaw/skills', 'token-optimizer', {
       homeDir,
+      pathModule: path.posix as unknown as typeof import('node:path'),
     })
     expect(result.ok).toBe(true)
     if (result.ok) {
@@ -39,13 +41,18 @@ describe('skills uninstall safety', () => {
       isAllowedOpenClawSkillsRoot('/Users/demo/.openclaw/workspace-feishu-default/skills', {
         homeDir,
         rootKind: 'workspace',
+        pathModule: path.posix as unknown as typeof import('node:path'),
       })
     ).toBe(true)
 
     const result = resolveSkillPathUnderRoot(
       '/Users/demo/.openclaw/workspace-feishu-default/skills',
       'token-manager',
-      { homeDir, rootKind: 'workspace' }
+      {
+        homeDir,
+        rootKind: 'workspace',
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }
     )
     expect(result.ok).toBe(true)
   })
@@ -53,18 +60,23 @@ describe('skills uninstall safety', () => {
   it('rejects unsafe fallback names', () => {
     const result = resolveManagedSkillFallbackPath('/Users/demo/.openclaw/skills', '../../etc', {
       homeDir,
+      pathModule: path.posix as unknown as typeof import('node:path'),
     })
     expect(result.ok).toBe(false)
   })
 
   it('rejects non-standard skills roots outside .openclaw', () => {
     expect(
-      resolveManagedSkillFallbackPath('/tmp/openclaw/custom-skills', 'token-optimizer', { homeDir }).ok
+      resolveManagedSkillFallbackPath('/tmp/openclaw/custom-skills', 'token-optimizer', {
+        homeDir,
+        pathModule: path.posix as unknown as typeof import('node:path'),
+      }).ok
     ).toBe(false)
     expect(
       resolveSkillPathUnderRoot('/Users/demo/.openclaw/custom-skills', 'token-manager', {
         homeDir,
         rootKind: 'workspace',
+        pathModule: path.posix as unknown as typeof import('node:path'),
       }).ok
     ).toBe(false)
   })

--- a/electron/main/node-subprocess-runtime.ts
+++ b/electron/main/node-subprocess-runtime.ts
@@ -14,6 +14,10 @@ import { buildCliPathWithCandidates, listExecutablePathCandidates } from './runt
 import { MAIN_RUNTIME_POLICY } from './runtime-policy'
 import { resolveSafeWorkingDirectory } from './runtime-working-directory'
 
+function joinForPlatform(platform: NodeJS.Platform, ...parts: string[]): string {
+  return (platform === 'win32' ? path.win32 : path.posix).join(...parts)
+}
+
 export interface QualifiedNodeRuntime {
   executablePath: string
   version: string
@@ -239,14 +243,27 @@ export async function resolveQualifiedNodeRuntime(
     const candidateBins = Array.from(
       new Set(
         [
-          targetVersion ? path.join(nvmDir, 'versions', 'node', `v${targetVersion.replace(/^v/, '')}`, 'bin') : '',
+          targetVersion
+            ? joinForPlatform(
+                platform,
+                nvmDir,
+                'versions',
+                'node',
+                `v${targetVersion.replace(/^v/, '')}`,
+                'bin'
+              )
+            : '',
           ...(await listInstalledNvmNodeBinDirsImpl(nvmDir).catch(() => [])),
         ].filter(Boolean)
       )
     )
 
     for (const candidateBin of candidateBins) {
-      const executablePath = path.join(candidateBin, platform === 'win32' ? 'node.exe' : 'node')
+      const executablePath = joinForPlatform(
+        platform,
+        candidateBin,
+        platform === 'win32' ? 'node.exe' : 'node'
+      )
       nvmCandidate = await probeRuntimeCandidate(
         executablePath,
         { timeoutMs, env: lookupEnv, cwd },

--- a/electron/main/nvm-node-runtime.ts
+++ b/electron/main/nvm-node-runtime.ts
@@ -66,13 +66,13 @@ export function normalizeNvmVersionTag(version: string): string {
 export function buildNvmNodeBinDir(
   nvmDir: string,
   version: string,
-  pathModule: typeof import('node:path') = path
+  pathModule: typeof import('node:path') = path.posix
 ): string {
   return pathModule.join(nvmDir, 'versions', 'node', normalizeNvmVersionTag(version), 'bin')
 }
 
 export function buildNvmShellPrefix(nvmDir: string): string {
-  return `export NVM_DIR=${quotePosixShellArg(nvmDir)} && source ${quotePosixShellArg(path.join(nvmDir, 'nvm.sh'))}`
+  return `export NVM_DIR=${quotePosixShellArg(nvmDir)} && source ${quotePosixShellArg(path.posix.join(nvmDir, 'nvm.sh'))}`
 }
 
 export function buildNvmInstallCommand(nvmDir: string, targetVersion: string): string {
@@ -92,7 +92,7 @@ export async function listInstalledNvmNodeBinDirs(
   const readdir =
     options.readdir ||
     ((targetPath, readOptions) => fsPromises.readdir(targetPath, readOptions))
-  const pathModule = options.pathModule || path
+  const pathModule = options.pathModule || path.posix
 
   let entries: Array<NvmDirentLike | import('node:fs').Dirent> = []
   try {
@@ -117,7 +117,7 @@ export async function detectNvmDir(
       await fsPromises.access(targetPath)
     })
   const homedir = options.homedir || (() => process.env.HOME || '')
-  const pathModule = options.pathModule || path
+  const pathModule = options.pathModule || path.posix
 
   const configuredNvmDir = String(env.NVM_DIR || '').trim()
   if (configuredNvmDir) return configuredNvmDir

--- a/electron/main/openclaw-install-permissions.ts
+++ b/electron/main/openclaw-install-permissions.ts
@@ -4,6 +4,10 @@ const os = process.getBuiltinModule('node:os') as typeof import('node:os')
 const { dirname, join } = path
 const { homedir, userInfo } = os
 
+function joinForPlatform(platform: NodeJS.Platform, ...parts: string[]): string {
+  return (platform === 'win32' ? path.win32 : path.posix).join(...parts)
+}
+
 export interface OpenClawInstallPermissionResultLike {
   ok: boolean
   stdout?: string
@@ -40,7 +44,7 @@ export function resolveOpenClawGlobalInstallProbePath(
   if (!normalizedPrefix) return normalizedPrefix
   const segments =
     platform === 'win32' ? ['node_modules', 'openclaw'] : ['lib', 'node_modules', 'openclaw']
-  return join(normalizedPrefix, ...segments)
+  return joinForPlatform(platform, normalizedPrefix, ...segments)
 }
 
 export async function probeOpenClawInstallPath(pathname: string): Promise<OpenClawInstallPathProbe> {

--- a/electron/main/openclaw-npm-runtime.ts
+++ b/electron/main/openclaw-npm-runtime.ts
@@ -4,7 +4,8 @@ import { resolveSafeWorkingDirectory } from './runtime-working-directory'
 const { mkdtemp, mkdir, writeFile } = process.getBuiltinModule('node:fs/promises') as typeof import('node:fs/promises')
 const { randomUUID } = process.getBuiltinModule('node:crypto') as typeof import('node:crypto')
 const { tmpdir } = process.getBuiltinModule('node:os') as typeof import('node:os')
-const { join } = process.getBuiltinModule('node:path') as typeof import('node:path')
+const path = process.getBuiltinModule('node:path') as typeof import('node:path')
+const { join } = path
 
 const OPENCLAW_MANAGED_NPM_SUBDIR = join('openclaw-installer', 'npm')
 const OPENCLAW_MANAGED_NPM_USERCONFIG = 'user.npmrc'
@@ -13,6 +14,10 @@ const OPENCLAW_MANAGED_NPM_CACHE_DIR = 'cache'
 const OPENCLAW_PRIVILEGED_NPM_CACHE_PREFIX = 'qclaw-openclaw-admin-npm'
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000
 const DEFAULT_FETCH_RETRIES = 2
+
+function joinForPlatform(platform: NodeJS.Platform, ...parts: string[]): string {
+  return (platform === 'win32' ? path.win32 : path.posix).join(...parts)
+}
 
 const MANAGED_NPM_CONFIG_CONTENT = [
   'fund=false',
@@ -91,7 +96,12 @@ export function createPrivilegedOpenClawNpmCommandOptions(
     String(overrides.tempDir || '').trim() ||
     (platform === 'darwin' ? '/private/tmp' : tmpdir())
   const suffix = String(overrides.uuidFactory?.() || randomUUID()).trim() || 'run'
-  const cachePath = join(tempRoot, `${OPENCLAW_PRIVILEGED_NPM_CACHE_PREFIX}-${suffix}`, 'cache')
+  const cachePath = joinForPlatform(
+    platform,
+    tempRoot,
+    `${OPENCLAW_PRIVILEGED_NPM_CACHE_PREFIX}-${suffix}`,
+    'cache'
+  )
 
   return {
     ...options,

--- a/electron/main/openclaw-skills.ts
+++ b/electron/main/openclaw-skills.ts
@@ -3,6 +3,8 @@ import { parseJsonFromCommandResult, parseJsonFromOutput } from './openclaw-comm
 import { normalizeOpenClawSkillsListPayload } from './skills-paths'
 import installWebPolicy from '../../install-web-v1.manifest.json'
 
+type PathModule = typeof import('node:path')
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -292,10 +294,13 @@ export function normalizeOpenClawSkillsPayload(
   payload: Record<string, unknown>,
   options: {
     config?: Record<string, unknown> | null
+    pathModule?: PathModule
   } = {}
 ): Record<string, unknown> {
   const normalizedPayload = mergeBundledManifestSkills({
-    payload: normalizeOpenClawSkillsListPayload(payload),
+    payload: normalizeOpenClawSkillsListPayload(payload, {
+      pathModule: options.pathModule,
+    }),
     config: options.config,
   })
   const rawSkills = Array.isArray(normalizedPayload.skills) ? normalizedPayload.skills : []

--- a/electron/main/skills-uninstall-safety.ts
+++ b/electron/main/skills-uninstall-safety.ts
@@ -2,10 +2,12 @@ const os = process.getBuiltinModule('node:os') as typeof import('node:os')
 const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
 const SKILL_SLUG_REGEX = /^[a-z0-9][a-z0-9._-]*$/i
+type PathModule = typeof import('node:path')
 
 interface ResolveSkillPathOptions {
   homeDir?: string
   rootKind?: 'managed' | 'workspace'
+  pathModule?: PathModule
 }
 
 function normalizePathValue(value: unknown): string {
@@ -16,17 +18,18 @@ export function isAllowedOpenClawSkillsRoot(
   skillsRootDir: string,
   options: ResolveSkillPathOptions = {}
 ): boolean {
+  const pathModule = options.pathModule || path
   const homeDir = normalizePathValue(options.homeDir || os.homedir())
   if (!homeDir) return false
 
-  const stateRoot = path.resolve(homeDir, '.openclaw')
-  const skillsRoot = path.resolve(skillsRootDir)
-  const relative = path.relative(stateRoot, skillsRoot)
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+  const stateRoot = pathModule.resolve(homeDir, '.openclaw')
+  const skillsRoot = pathModule.resolve(skillsRootDir)
+  const relative = pathModule.relative(stateRoot, skillsRoot)
+  if (!relative || relative.startsWith('..') || pathModule.isAbsolute(relative)) {
     return false
   }
 
-  const segments = relative.split(path.sep).filter(Boolean)
+  const segments = relative.split(pathModule.sep).filter(Boolean)
   if (options.rootKind === 'managed') {
     return segments.length === 1 && segments[0] === 'skills'
   }
@@ -76,6 +79,7 @@ export function resolveSkillPathUnderRoot(
   skillSlug: string,
   options: ResolveSkillPathOptions = {}
 ): { ok: true; skillsRoot: string; targetPath: string } | { ok: false; error: string } {
+  const pathModule = options.pathModule || path
   const safeSlug = normalizeSafeSkillSlug(skillSlug)
   if (!safeSlug) {
     return { ok: false, error: 'invalid-skill-slug' }
@@ -86,14 +90,14 @@ export function resolveSkillPathUnderRoot(
     return { ok: false, error: 'invalid-managed-skills-dir' }
   }
 
-  const skillsRoot = path.resolve(normalizedSkillsRootDir)
+  const skillsRoot = pathModule.resolve(normalizedSkillsRootDir)
   if (!isAllowedOpenClawSkillsRoot(skillsRoot, options)) {
     return { ok: false, error: 'unsafe-skills-root' }
   }
 
-  const targetPath = path.resolve(skillsRoot, safeSlug)
-  const relative = path.relative(skillsRoot, targetPath)
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+  const targetPath = pathModule.resolve(skillsRoot, safeSlug)
+  const relative = pathModule.relative(skillsRoot, targetPath)
+  if (!relative || relative.startsWith('..') || pathModule.isAbsolute(relative)) {
     return { ok: false, error: 'unsafe-fallback-path' }
   }
 

--- a/src/pages/__tests__/dashboard-gateway-wait.test.ts
+++ b/src/pages/__tests__/dashboard-gateway-wait.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { waitForDashboardGatewayRunning } from '../Dashboard'
 
 const FAST_POLL_POLICY = {
-  timeoutMs: 50,
+  timeoutMs: 200,
   initialIntervalMs: 1,
   maxIntervalMs: 1,
   backoffFactor: 1,

--- a/src/pages/__tests__/dashboard-gateway-wait.test.ts
+++ b/src/pages/__tests__/dashboard-gateway-wait.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { waitForDashboardGatewayRunning } from '../Dashboard'
 
 const FAST_POLL_POLICY = {
-  timeoutMs: 10,
+  timeoutMs: 50,
   initialIntervalMs: 1,
   maxIntervalMs: 1,
   backoffFactor: 1,


### PR DESCRIPTION
 ## 背景

  当前仓库在补齐多平台 CI 后，暴露出一批测试对平台细节的隐式假设，尤其是在 Windows 下会受到以下差异影响：

  - 路径分隔符差异（`/` 与 `\`）
  - `npm` / `npm.cmd` 的可执行名差异
  - CRLF 与 LF 的换行差异
  - Windows 短路径 / 长路径别名（如 `RUNNER~1` 与 `runneradmin`）导致的路径断言失败
  - 少量依赖时序的测试在 Windows runner 上更容易超时

  这次 PR 主要做两件事：补齐跨平台 CI，以及把这批测试改成真正的平台无关。

  ## 本次改动

  - 将 GitHub Actions CI 补齐为三平台矩阵：
    - `ubuntu-latest`
    - `windows-latest`
    - `macos-latest`
  - 三平台统一执行 smoke verify
  - 三平台统一执行完整 `Vitest`
  - 保留 `ubuntu-latest` 的 model regression 检查
  - 修复一批 Windows 下不稳定或失败的测试，重点包括：
    - 路径拼接和路径断言改为平台感知
    - `npm.cmd` 相关断言兼容 Windows
    - CRLF fixture / 文本匹配兼容
    - NVM / runtime / skills 相关测试中的 POSIX 路径假设修正
    - 个别容易在 Windows runner 上抖动的测试适当放宽超时
  - 额外修复 `openclaw-package` 相关测试中 Windows runner 短路径 / 长路径别名造成的误报，改为比较归一化后的真实路径位置

  ## 验证

  本地已验证：

  - `npm test` 通过
  - `npm run typecheck` 通过
  - `npm run build:app` 通过
  - `npm run test:model-regression -- --skip-typecheck` 通过

  CI 已验证：

  - 最新 workflow 全部通过
  - `Smoke verify`：Ubuntu / Windows / macOS 全通过
  - `Vitest`：Ubuntu / Windows / macOS 全通过
  - `Model regression`：Ubuntu 通过

  ## 影响

  这次改动主要是 CI 和测试兼容性增强，不涉及预期的业务行为变更。目标是让后续功能改动能更早在多平台上暴露问题，减少
  Windows / macOS 的回归漏检。