### PR TITLE
fix: improve local dev onboarding experience

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -558,7 +558,7 @@ export default function Dashboard({
 
   const getUpstreamModelState = async () => {
     const upstreamState = await readOpenClawUpstreamModelState()
-    logUpstreamModelStateFallback('Dashboard', upstreamState)
+    logUpstreamModelStateFallback('Dashboard', upstreamState, console.info, import.meta.env.DEV)
     return upstreamState
   }
 

--- a/src/pages/EnvCheck.tsx
+++ b/src/pages/EnvCheck.tsx
@@ -507,6 +507,16 @@ export function createEnvCheckRestartState(currentRunAttempt: number): EnvCheckR
   }
 }
 
+export function buildDevBypassReadyPayload(): EnvCheckReadyPayload {
+  return {
+    hadOpenClawInstalled: false,
+    installedOpenClawDuringCheck: false,
+    gatewayRunning: false,
+    sharedConfigInitialized: false,
+    discoveryResult: null,
+  }
+}
+
 function TakeoverNotification({
   backupRootDirectory,
   failures,
@@ -703,6 +713,7 @@ export default function EnvCheck({
   const [historyOnlyRecoveryFailure, setHistoryOnlyRecoveryFailure] =
     useState<HistoryOnlyRecoveryFailureState | null>(null)
   const [historyOnlyRecoveryConfirmOpened, setHistoryOnlyRecoveryConfirmOpened] = useState(false)
+  const canBypassInDev = import.meta.env.DEV
 
   const updateStep = (id: string, update: Partial<Step>) => {
     setSteps(prev => prev.map(s => s.id === id ? { ...s, ...update } : s))
@@ -796,6 +807,10 @@ export default function EnvCheck({
   const handleRestartEnvCheck = () => {
     closeStartupIssue()
     resetEnvCheck(runAttempt)
+  }
+
+  const handleDevBypass = () => {
+    onReady(buildDevBypassReadyPayload())
   }
 
   const inspectExistingOpenClaw = async (
@@ -1721,6 +1736,16 @@ export default function EnvCheck({
               修复坏插件环境
             </Button>
           </Tooltip>
+          {canBypassInDev && (
+            <Button
+              size="compact-xs"
+              variant="light"
+              color="yellow"
+              onClick={handleDevBypass}
+            >
+              开发调试：跳过环境检测
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/pages/ModelsPage.tsx
+++ b/src/pages/ModelsPage.tsx
@@ -1028,7 +1028,7 @@ export default function ModelsPage() {
       setEnvVars(env)
       setConfig(cfg)
 
-      logUpstreamModelStateFallback('ModelsPage', upstreamState)
+      logUpstreamModelStateFallback('ModelsPage', upstreamState, console.info, import.meta.env.DEV)
 
       const upstreamStatusData = getUpstreamModelStatusLike(upstreamState)
       const upstreamCatalog = getUpstreamCatalogItemsLike(upstreamState)

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -60,12 +60,15 @@ export default function Welcome({ onAccept }: WelcomeProps) {
           <IconPinFilled size={12} className="text-red-400 flex-shrink-0" />
           <Text fw={600} size="sm" className="app-text-primary">环境风险</Text>
         </div>
-        <Text size="xs" className="app-text-warning mt-0.5 font-medium">
+        <div
+          className="app-text-warning mt-0.5 font-medium"
+          style={{ fontSize: 'var(--mantine-font-size-xs)', lineHeight: 'var(--mantine-line-height-xs)' }}
+        >
           <ul className="list-disc list-inside app-text-secondary mt-0.5 flex flex-col" style={{ fontSize: '12.5px', lineHeight: 1.7 }}>
-          <li><span className="app-text-warning font-medium">Openclaw权限较大，不建议使用含有重要文件的工作电脑。</span></li>  
-          <li>对于开发者：当前Openclaw 要求 Node.js 版本高于22.16，如果您本地的 Node.js 低于22.16，Qclaw 会自动安装最新版node，可能造成node版本覆盖。</li>  
-        </ul>
-        </Text>
+            <li><span className="app-text-warning font-medium">Openclaw权限较大，不建议使用含有重要文件的工作电脑。</span></li>
+            <li>对于开发者：当前Openclaw 要求 Node.js 版本高于22.16，如果您本地的 Node.js 低于22.16，Qclaw 会自动安装最新版node，可能造成node版本覆盖。</li>
+          </ul>
+        </div>
       </div>
 
       {/* Checkbox */}

--- a/src/pages/__tests__/env-check-state.test.ts
+++ b/src/pages/__tests__/env-check-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import * as EnvCheckModule from '../EnvCheck'
+import envCheckSource from '../EnvCheck.tsx?raw'
 import {
   buildOpenClawAutoCorrectionConsentMessage,
+  buildDevBypassReadyPayload,
   buildOpenClawGateState,
   canContinueWithOpenClawGate,
   canContinueHistoryOnlyRecovery,
@@ -207,6 +209,21 @@ describe('createEnvCheckRestartState', () => {
     resolveRepair()
     await repairPromise
     expect(events).toEqual(['repair-started', 'after-kickoff', 'repair-settled'])
+  })
+
+  it('builds a dev bypass payload that routes back into setup instead of pretending dashboard is ready', () => {
+    expect(buildDevBypassReadyPayload()).toEqual({
+      hadOpenClawInstalled: false,
+      installedOpenClawDuringCheck: false,
+      gatewayRunning: false,
+      sharedConfigInitialized: false,
+      discoveryResult: null,
+    })
+  })
+
+  it('renders a dev-only bypass action so vite electron sessions can skip env detection', () => {
+    expect(envCheckSource).toContain('开发调试：跳过环境检测')
+    expect(envCheckSource).toContain('import.meta.env.DEV')
   })
 
   it('treats 2026.3.22 as the minimum supported openclaw version after stripping suffixes', () => {

--- a/src/pages/__tests__/welcome.test.tsx
+++ b/src/pages/__tests__/welcome.test.tsx
@@ -24,4 +24,14 @@ describe('Welcome', () => {
     expect(html).toContain('当前Openclaw 要求 Node.js 版本高于22.16')
     expect(html).toContain('Qclaw 会自动安装最新版node，可能造成node版本覆盖')
   })
+
+  it('does not render list markup inside paragraph tags', () => {
+    const html = renderToStaticMarkup(
+      <MantineProvider>
+        <Welcome onAccept={vi.fn()} />
+      </MantineProvider>
+    )
+
+    expect(html).not.toMatch(/<p[^>]*>\s*<ul/)
+  })
 })

--- a/src/shared/__tests__/upstream-model-state.test.ts
+++ b/src/shared/__tests__/upstream-model-state.test.ts
@@ -146,6 +146,19 @@ describe('upstream model state helpers', () => {
       'control-ui-down'
     )
   })
+
+  it('stays silent when fallback logging is explicitly disabled', () => {
+    const logger = vi.fn()
+
+    logUpstreamModelStateFallback(
+      'Dashboard',
+      createUnavailableUpstreamModelState('control-ui-down'),
+      logger,
+      false
+    )
+
+    expect(logger).not.toHaveBeenCalled()
+  })
 })
 
 describe('selectPreferredRendererCatalogItems', () => {

--- a/src/shared/upstream-model-state.ts
+++ b/src/shared/upstream-model-state.ts
@@ -78,8 +78,10 @@ export async function readOpenClawUpstreamModelState(
 export function logUpstreamModelStateFallback(
   scope: string,
   state: RendererUpstreamModelStateResult,
-  logger: (...args: unknown[]) => void = console.info
+  logger: (...args: unknown[]) => void = console.info,
+  enabled = true
 ): void {
+  if (!enabled) return
   if (!state.fallbackUsed || !state.fallbackReason) return
   logger(`[${scope}] upstream model state fallback:`, state.fallbackReason)
 }


### PR DESCRIPTION
## Summary
- add a dev-only bypass action for Electron/Vite sessions to skip blocking env detection
- fix invalid list markup in the welcome risk notice
- suppress upstream model fallback console logs outside dev mode

## Test Plan
- npm test -- src/pages/__tests__/env-check-state.test.ts src/pages/__tests__/welcome.test.tsx src/shared/__tests__/upstream-model-state.test.ts
- npm run typecheck