### PR TITLE
feat: 添加 Linux 构建支持 (AppImage)

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -63,6 +63,19 @@
     "allowToChangeInstallationDirectory": true,
     "deleteAppDataOnUninstall": false
   },
+  "linux": {
+    "icon": "build/icon.png",
+    "category": "Development",
+    "artifactName": "Qclaw-Lite_${env.QCLAW_DISPLAY_VERSION}.${ext}",
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": [
+          "x64"
+        ]
+      }
+    ]
+  },
   "publish": {
     "provider": "generic",
     "channel": "latest",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "package:mac": "npm run check:mac:release-env -- --allow-placeholder-publish --skip-notarize && npm run build:app && QCLAW_SKIP_NOTARIZE=1 node scripts/run-electron-builder.mjs --mac --publish never",
     "package:mac:notarized": "npm run check:mac:release-env -- --allow-placeholder-publish && npm run build:app && node scripts/run-electron-builder.mjs --mac --publish never",
     "release:mac": "npm run check:mac:release-env && npm run build:app && node scripts/run-electron-builder.mjs --mac --publish never",
+    "package:linux": "npm run build:app && node scripts/run-electron-builder.mjs --linux -c.forceCodeSigning=false --publish never",
     "release:prepare-cos": "node scripts/prepare-cos-update-release.mjs",
     "preview": "vite preview",
     "pretest": "vite build --mode=test",

--- a/scripts/after-all-artifact-build.cjs
+++ b/scripts/after-all-artifact-build.cjs
@@ -53,6 +53,8 @@ function parseCodesignDetails(output) {
 }
 
 async function afterAllArtifactBuild(buildResult) {
+  if (process.platform !== 'darwin') return []
+
   const appBundles = findAppBundles(buildResult.outDir)
   if (appBundles.length === 0) return []
 


### PR DESCRIPTION
## 关联 Issue

关闭 #62

## 变更说明

在 3 个文件中做了最小改动，实现 Linux AppImage 构建支持：

- **`electron-builder.json`** — 新增 `linux` 配置块，目标格式 AppImage (x64)
- **`package.json`** — 新增 `package:linux` 构建脚本
- **`scripts/after-all-artifact-build.cjs`** — 为 `codesign` 验证添加 macOS 平台守卫（该工具在 Linux 上不存在）

`forceCodeSigning` 通过 `package:linux` 脚本中的 `-c.forceCodeSigning=false` 参数覆盖，Mac 构建流程不受任何影响。

## 测试

- [x] 在 Ubuntu 24.04 x64 上执行 `npm run package:linux` 构建成功
- [x] 生成 `Qclaw-Lite_*.AppImage`，可正常启动

🤖 Generated with [Claude Code](https://claude.com/claude-code)