### PR TITLE
feat: add Linux build support

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "com.qclawai.qclaw",
   "asar": true,
-  "forceCodeSigning": true,
+  "forceCodeSigning": false,
   "afterSign": "scripts/after-sign-notarize.cjs",
   "afterAllArtifactBuild": "scripts/after-all-artifact-build.cjs",
   "directories": {
@@ -62,6 +62,31 @@
     "perMachine": false,
     "allowToChangeInstallationDirectory": true,
     "deleteAppDataOnUninstall": false
+  },
+  "linux": {
+    "icon": "build/icon.png",
+    "category": "Development",
+    "artifactName": "Qclaw-Lite_${env.QCLAW_DISPLAY_VERSION}.${ext}",
+    "target": [
+      {
+        "target": "AppImage",
+        "arch": [
+          "x64"
+        ]
+      },
+      {
+        "target": "deb",
+        "arch": [
+          "x64"
+        ]
+      },
+      {
+        "target": "rpm",
+        "arch": [
+          "x64"
+        ]
+      }
+    ]
   },
   "publish": {
     "provider": "generic",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "com.qclawai.qclaw",
   "asar": true,
-  "forceCodeSigning": false,
   "afterSign": "scripts/after-sign-notarize.cjs",
   "afterAllArtifactBuild": "scripts/after-all-artifact-build.cjs",
   "directories": {
@@ -67,6 +66,7 @@
     "icon": "build/icon.png",
     "category": "Development",
     "artifactName": "Qclaw-Lite_${env.QCLAW_DISPLAY_VERSION}.${ext}",
+    "forceCodeSigning": false,
     "target": [
       {
         "target": "AppImage",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "com.qclawai.qclaw",
   "asar": true,
+  "forceCodeSigning": true,
   "afterSign": "scripts/after-sign-notarize.cjs",
   "afterAllArtifactBuild": "scripts/after-all-artifact-build.cjs",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "package:mac:dir": "npm run check:mac:release-env -- --allow-placeholder-publish --skip-notarize && npm run build:app && QCLAW_SKIP_NOTARIZE=1 node scripts/run-electron-builder.mjs --mac dir --publish never",
     "package:mac": "npm run check:mac:release-env -- --allow-placeholder-publish --skip-notarize && npm run build:app && QCLAW_SKIP_NOTARIZE=1 node scripts/run-electron-builder.mjs --mac --publish never",
     "package:mac:notarized": "npm run check:mac:release-env -- --allow-placeholder-publish && npm run build:app && node scripts/run-electron-builder.mjs --mac --publish never",
+    "package:linux": "npm run build:app && node scripts/run-electron-builder.mjs --linux --publish never",
+    "package:linux:dir": "npm run build:app && node scripts/run-electron-builder.mjs --linux dir --publish never",
     "release:mac": "npm run check:mac:release-env && npm run build:app && node scripts/run-electron-builder.mjs --mac --publish never",
     "release:prepare-cos": "node scripts/prepare-cos-update-release.mjs",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

This PR adds Linux build support to Qclaw, enabling users on Ubuntu, Debian, Fedora, and other Linux distributions to install and use the application.

## Changes

### electron-builder.json
- Added Linux configuration supporting multiple package formats:
  - **AppImage** - Universal portable format (works on most distros)
  - **deb** - For Debian/Ubuntu-based distributions
  - **rpm** - For Fedora/RHEL-based distributions
- Disabled `forceCodeSigning` to allow cross-platform builds (macOS code signing is still performed when building on macOS)
- Set appropriate Linux category (Development)

### package.json
- Added `package:linux` script - Build Linux packages (AppImage, deb, rpm)
- Added `package:linux:dir` script - Build Linux directory (useful for testing)

## Testing

Verified working on:
- ✅ Ubuntu 22.04+ (x64)
- Build produces working binaries

## Usage

```bash
# Install dependencies
npm install

# Build Linux packages
npm run package:linux

# Or build just the directory (faster, for testing)
npm run package:linux:dir
```

## Notes

- Linux builds do not require code signing
- AppImage is the most portable format and recommended for distribution
- deb and rpm packages provide better system integration

## Related

This addresses the "Linux (计划中)" item in the README.

---

*This contribution was made by [Patbby](https://github.com/Patbby) with AI assistance.*