### PR TITLE
feat: 新增Agent 管理、飞书多 Bot 简化改造

### DIFF
--- a/electron/main/cli.ts
+++ b/electron/main/cli.ts
@@ -2920,14 +2920,6 @@ function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function getManagedFeishuAgentId(accountId: string): string {
-  return `feishu-${accountId === 'default' ? 'default' : sanitizeStoreKey(accountId)}`
-}
-
-function getManagedFeishuWorkspace(accountId: string): string {
-  return `~/.openclaw/workspace-feishu-${accountId === 'default' ? 'default' : sanitizeStoreKey(accountId)}`
-}
-
 export async function getFeishuBotRuntimeStatuses(): Promise<Record<string, FeishuBotRuntimeStatus>> {
   const config = await readConfig()
   const gateway = await gatewayHealth().catch(() => ({ running: false } as GatewayHealthCheckResult))
@@ -2935,7 +2927,7 @@ export async function getFeishuBotRuntimeStatuses(): Promise<Record<string, Feis
   const agents = Array.isArray(config?.agents?.list) ? config?.agents?.list : []
   const bindings = Array.isArray(config?.bindings) ? config?.bindings : []
   const pluginConfigured = Array.isArray(config?.plugins?.allow)
-    ? config?.plugins?.allow.some((item: unknown) => String(item || '').trim() === 'openclaw-lark')
+    ? config?.plugins?.allow.some((item: unknown) => String(item || '').trim() === 'feishu')
     : false
   const dmScopeCorrect = normalizeText(config?.session?.dmScope) === 'per-account-channel-peer'
 
@@ -2967,8 +2959,7 @@ export async function getFeishuBotRuntimeStatuses(): Promise<Record<string, Feis
 
   const result: Record<string, FeishuBotRuntimeStatus> = {}
   for (const bot of bots) {
-    const agentId = getManagedFeishuAgentId(bot.accountId)
-    const workspace = getManagedFeishuWorkspace(bot.accountId)
+    const agentId = bot.accountId
     const issues: string[] = []
     const managedAgent = agents.find((agent: any) => normalizeText(agent?.id) === agentId)
     const matchingBindings = bindings.filter(
@@ -2984,15 +2975,13 @@ export async function getFeishuBotRuntimeStatuses(): Promise<Record<string, Feis
       issues.push('缺少完整的 App ID / App Secret。')
     }
     if (!pluginConfigured) {
-      issues.push('openclaw-lark 插件未在配置中启用。')
+      issues.push('feishu 插件未在配置中启用。')
     }
     if (!dmScopeCorrect) {
       issues.push('session.dmScope 不是 per-account-channel-peer。')
     }
     if (!managedAgent) {
-      issues.push(`缺少托管 Agent：${agentId}。`)
-    } else if (normalizeText(managedAgent.workspace) !== workspace) {
-      issues.push(`Agent workspace 未隔离到 ${workspace}。`)
+      issues.push(`未找到绑定的 Agent：${agentId}。`)
     }
     if (!matchingBindings.some((binding: any) => normalizeText(binding?.agentId) === agentId)) {
       issues.push(`缺少 accountId=${bot.accountId} 的路由绑定。`)
@@ -3020,7 +3009,7 @@ export async function getFeishuBotRuntimeStatuses(): Promise<Record<string, Feis
     result[bot.accountId] = {
       accountId: bot.accountId,
       agentId,
-      workspace,
+      workspace: managedAgent?.workspace || '',
       enabled: bot.enabled,
       credentialsComplete: bot.credentialsComplete,
       gatewayRunning: Boolean(gateway.running),

--- a/electron/main/feishu-official-plugin-state.ts
+++ b/electron/main/feishu-official-plugin-state.ts
@@ -9,13 +9,10 @@ import { applyConfigPatchGuarded } from './openclaw-config-coordinator'
 import { FEISHU_PLUGIN_NPX_SPECIFIER } from './plugin-install-npx'
 import { reloadGatewayForConfigChange } from './gateway-lifecycle-controller'
 
-const fs = process.getBuiltinModule('node:fs') as typeof import('node:fs')
 const path = process.getBuiltinModule('node:path') as typeof import('node:path')
 
-const FEISHU_OFFICIAL_PLUGIN_ID = 'openclaw-lark'
-const FEISHU_OFFICIAL_PLUGIN_SPEC = '@larksuite/openclaw-lark'
-const FEISHU_OFFICIAL_PLUGIN_MANIFEST = 'openclaw.plugin.json'
-const LEGACY_FEISHU_PLUGIN_IDS = ['feishu', 'feishu-openclaw-plugin']
+const FEISHU_OFFICIAL_PLUGIN_ID = 'feishu'
+const LEGACY_FEISHU_PLUGIN_IDS = ['openclaw-lark', 'feishu-openclaw-plugin']
 const FEISHU_PLUGIN_REPAIR_SCOPE = [FEISHU_OFFICIAL_PLUGIN_ID, ...LEGACY_FEISHU_PLUGIN_IDS]
 
 function cloneConfig(config: Record<string, any> | null | undefined): Record<string, any> {
@@ -31,10 +28,6 @@ function hasOwnRecord(value: unknown): value is Record<string, any> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-function isBuiltInFeishuPluginExplicitlyDisabled(value: unknown): boolean {
-  return hasOwnRecord(value) && value.enabled === false
-}
-
 function collectLegacyPluginIds(config: Record<string, any>): string[] {
   const found = new Set<string>()
   const allow = Array.isArray(config.plugins?.allow) ? config.plugins.allow : []
@@ -45,12 +38,6 @@ function collectLegacyPluginIds(config: Record<string, any>): string[] {
 
   const entries = hasOwnRecord(config.plugins?.entries) ? config.plugins.entries : {}
   for (const pluginId of Object.keys(entries)) {
-    if (
-      pluginId === 'feishu' &&
-      isBuiltInFeishuPluginExplicitlyDisabled(entries[pluginId])
-    ) {
-      continue
-    }
     if (LEGACY_FEISHU_PLUGIN_IDS.includes(pluginId)) found.add(pluginId)
   }
 
@@ -63,9 +50,7 @@ function collectLegacyPluginIds(config: Record<string, any>): string[] {
 }
 
 function sanitizeLegacyFeishuPluginConfig(config: Record<string, any>): { config: Record<string, any>; changed: boolean } {
-  return sanitizeManagedPluginConfig(config, {
-    preserveBuiltInFeishuDisable: true,
-  })
+  return sanitizeManagedPluginConfig(config, {})
 }
 
 function stripOfficialFeishuPluginConfig(config: Record<string, any>): { config: Record<string, any>; changed: boolean } {
@@ -106,26 +91,14 @@ function isOfficialPluginEnabled(config: Record<string, any>): boolean {
 }
 
 function ensureOfficialPluginInstallRecord(
-  config: Record<string, any>,
-  installPath: string
+  config: Record<string, any>
 ): Record<string, any> {
   const next = cloneConfig(config)
   next.plugins = hasOwnRecord(next.plugins) ? next.plugins : {}
-  next.plugins.installs = hasOwnRecord(next.plugins.installs) ? next.plugins.installs : {}
-
-  const existingInstall = hasOwnRecord(next.plugins.installs[FEISHU_OFFICIAL_PLUGIN_ID])
-    ? next.plugins.installs[FEISHU_OFFICIAL_PLUGIN_ID]
-    : {}
-
-  next.plugins.installs[FEISHU_OFFICIAL_PLUGIN_ID] = {
-    ...existingInstall,
-    source: normalizeText(existingInstall.source) || 'npm',
-    spec: normalizeText(existingInstall.spec) || FEISHU_OFFICIAL_PLUGIN_SPEC,
-    ...(installPath
-      ? {
-          installPath: normalizeText(existingInstall.installPath) || installPath,
-        }
-      : {}),
+  next.plugins.entries = hasOwnRecord(next.plugins.entries) ? next.plugins.entries : {}
+  next.plugins.entries[FEISHU_OFFICIAL_PLUGIN_ID] = {
+    ...(next.plugins.entries[FEISHU_OFFICIAL_PLUGIN_ID] || {}),
+    enabled: true,
   }
 
   return next
@@ -157,7 +130,6 @@ function shouldApplyFeishuIsolation(config: Record<string, any>): boolean {
 function buildNormalizedConfig(params: {
   config: Record<string, any>
   installedOnDisk: boolean
-  installPath: string
 }): Record<string, any> {
   const sanitized = sanitizeLegacyFeishuPluginConfig(params.config).config
   if (!params.installedOnDisk) {
@@ -167,7 +139,7 @@ function buildNormalizedConfig(params: {
       : stripped
   }
 
-  const withInstallRecord = ensureOfficialPluginInstallRecord(sanitized, params.installPath)
+  const withInstallRecord = ensureOfficialPluginInstallRecord(sanitized)
   const withAllowlist = reconcileTrustedPluginAllowlist(withInstallRecord).config
   return applyFeishuMultiBotIsolation(withAllowlist)
 }
@@ -176,18 +148,8 @@ function isStateReady(state: FeishuOfficialPluginState): boolean {
   return state.installedOnDisk && state.officialPluginConfigured
 }
 
-function resolveFeishuOfficialPluginManifestPath(homeDir: string): string {
-  return path.join(homeDir, 'extensions', FEISHU_OFFICIAL_PLUGIN_ID, FEISHU_OFFICIAL_PLUGIN_MANIFEST)
-}
-
-async function isFeishuOfficialPluginInstalledOnDisk(homeDir: string): Promise<boolean> {
-  if (!homeDir) return false
-  try {
-    await fs.promises.access(resolveFeishuOfficialPluginManifestPath(homeDir))
-    return true
-  } catch {
-    return false
-  }
+async function isFeishuOfficialPluginInstalledOnDisk(_homeDir: string): Promise<boolean> {
+  return true
 }
 
 export interface FeishuOfficialPluginState {
@@ -251,7 +213,6 @@ export async function getFeishuOfficialPluginState(): Promise<FeishuOfficialPlug
   const normalizedConfig = buildNormalizedConfig({
     config: baseConfig,
     installedOnDisk,
-    installPath,
   })
   const configChanged = JSON.stringify(normalizedConfig) !== JSON.stringify(baseConfig)
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -54,6 +54,8 @@ let appExitCleanupPromise: Promise<void> | null = null
 let isQuitting = false
 const preload = path.join(__dirname, '../preload/index.mjs')
 const indexHtml = path.join(RENDERER_DIST, 'index.html')
+const DEV_SERVER_RETRY_MAX_ATTEMPTS = 20
+const DEV_SERVER_RETRY_INTERVAL_MS = 500
 const focusApp = process.platform === 'darwin'
   ? (options: { steal: boolean }) => app.focus(options)
   : undefined
@@ -122,6 +124,40 @@ function createWindow() {
   })
 
   if (VITE_DEV_SERVER_URL) {
+    let devServerRetryAttempts = 0
+    let devServerRetryTimer: NodeJS.Timeout | null = null
+
+    const clearDevServerRetryTimer = () => {
+      if (devServerRetryTimer) {
+        clearTimeout(devServerRetryTimer)
+        devServerRetryTimer = null
+      }
+    }
+
+    const scheduleDevServerRetry = () => {
+      if (devServerRetryAttempts >= DEV_SERVER_RETRY_MAX_ATTEMPTS) return
+      devServerRetryAttempts += 1
+      clearDevServerRetryTimer()
+      devServerRetryTimer = setTimeout(() => {
+        if (browserWindow.isDestroyed()) return
+        void browserWindow.loadURL(VITE_DEV_SERVER_URL)
+      }, DEV_SERVER_RETRY_INTERVAL_MS)
+    }
+
+    browserWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      if (!isMainFrame || validatedURL !== VITE_DEV_SERVER_URL) return
+      if (!String(errorDescription || '').includes('ERR_EMPTY_RESPONSE') && errorCode !== -102) return
+      scheduleDevServerRetry()
+    })
+
+    browserWindow.webContents.on('did-finish-load', () => {
+      clearDevServerRetryTimer()
+    })
+
+    browserWindow.on('closed', () => {
+      clearDevServerRetryTimer()
+    })
+
     void browserWindow.loadURL(VITE_DEV_SERVER_URL)
   } else {
     void browserWindow.loadFile(indexHtml)

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -1,6 +1,8 @@
 /**
  * IPC handlers — bridge between renderer and CLI
  */
+import path from 'node:path'
+import fs from 'node:fs'
 import { app, ipcMain, shell } from 'electron'
 import {
   checkNode,
@@ -919,6 +921,48 @@ export function registerIpcHandlers() {
     const payload = await getOpenClawSkillsListPayload()
     return resolveOpenClawSkillLocations(payload)
   }
+
+  ipcMain.handle('skills:workspaceList', async (_e, workspace: string) => {
+    try {
+      const skillsDir = path.join(workspace, 'skills')
+      const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true }).catch(() => [])
+      const skills = []
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const skillJsonPath = path.join(skillsDir, entry.name, 'skill.json')
+          try {
+            const content = await fs.promises.readFile(skillJsonPath, 'utf8')
+            const skill = JSON.parse(content)
+            skills.push({ ...skill, name: entry.name, title: skill.name || entry.name, source: 'openclaw-workspace', path: path.join(skillsDir, entry.name) })
+          } catch {
+            skills.push({ name: entry.name, title: entry.name, source: 'openclaw-workspace', description: '无法读取 skill.json', path: path.join(skillsDir, entry.name) })
+          }
+        }
+      }
+      return { ok: true, stdout: JSON.stringify(skills) }
+    } catch (e) {
+      return { ok: false, stderr: String(e) }
+    }
+  })
+
+  ipcMain.handle('skills:workspaceUninstall', async (_e, workspace: string, name: string) => {
+    try {
+      const skillPath = path.join(workspace, 'skills', name)
+      await fs.promises.rm(skillPath, { recursive: true, force: true })
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, stderr: String(e) }
+    }
+  })
+
+  ipcMain.handle('workspace:delete', async (_e, workspace: string) => {
+    try {
+      await fs.promises.rm(workspace, { recursive: true, force: true })
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, stderr: String(e) }
+    }
+  })
 
   ipcMain.handle('skills:uninstall', async (_e, name: string) => {
     const normalizedName = String(name || '').trim()

--- a/electron/main/official-channel-adapters.ts
+++ b/electron/main/official-channel-adapters.ts
@@ -177,16 +177,10 @@ async function getDingtalkOfficialChannelStatus(): Promise<OfficialChannelStatus
     },
     registered.evidence,
     {
-      source: 'status',
+      source: 'plugins-list',
       channelId: 'dingtalk',
       pluginId,
-      message: '当前尚无上游 loaded signal，loaded 保持 unknown / 未证实',
-    },
-    {
-      source: 'status',
-      channelId: 'dingtalk',
-      pluginId,
-      message: '当前尚无上游 channel status / probe，ready 保持 unknown / 未证实',
+      message: '当前缺少上游 loaded / ready 证明，状态保留为未知。',
     },
   ]
 
@@ -200,11 +194,9 @@ async function getDingtalkOfficialChannelStatus(): Promise<OfficialChannelStatus
     createStage(
       'registered',
       registered.state,
-      'plugins-list',
+      registered.evidence.source,
       registered.evidence.message
     ),
-    createStage('loaded', 'unknown', 'upstream-status-missing', '当前缺少上游 loaded 证明'),
-    createStage('ready', 'unknown', 'upstream-probe-missing', '当前缺少上游 ready 证明'),
   ]
 
   return {
@@ -248,16 +240,10 @@ async function getFeishuOfficialChannelStatus(): Promise<OfficialChannelStatusVi
         }]
       : []),
     {
-      source: 'status',
+      source: 'plugins-list',
       channelId: 'feishu',
       pluginId: state.pluginId,
-      message: '当前尚无统一上游 loaded signal，loaded 保持 unknown / 未证实',
-    },
-    {
-      source: 'status',
-      channelId: 'feishu',
-      pluginId: state.pluginId,
-      message: '当前尚无统一上游 channel status / probe，ready 保持 unknown / 未证实',
+      message: '当前缺少上游 loaded / ready 证明，状态保留为未知。',
     },
   ]
 
@@ -274,8 +260,6 @@ async function getFeishuOfficialChannelStatus(): Promise<OfficialChannelStatusVi
       'plugins-list',
       registered.evidence.message
     ),
-    createStage('loaded', 'unknown', 'upstream-status-missing', '当前缺少上游 loaded 证明'),
-    createStage('ready', 'unknown', 'upstream-probe-missing', '当前缺少上游 ready 证明'),
   ]
 
   return {

--- a/electron/main/openclaw-plugin-config.ts
+++ b/electron/main/openclaw-plugin-config.ts
@@ -1,11 +1,10 @@
-const BUILTIN_FEISHU_PLUGIN_ID = 'feishu'
-const FEISHU_OFFICIAL_PLUGIN_ID = 'openclaw-lark'
-const LEGACY_PLUGIN_IDS = new Set([BUILTIN_FEISHU_PLUGIN_ID, 'feishu-openclaw-plugin'])
-const LEGACY_PLUGIN_ENTRY_IDS = new Set(['feishu-openclaw-plugin'])
-const LEGACY_PLUGIN_INSTALL_IDS = new Set([BUILTIN_FEISHU_PLUGIN_ID, 'feishu-openclaw-plugin'])
+const FEISHU_OFFICIAL_PLUGIN_ID = 'feishu'
+const LEGACY_PLUGIN_IDS = new Set(['feishu-openclaw-plugin', 'openclaw-lark'])
+const LEGACY_PLUGIN_ENTRY_IDS = new Set(['feishu-openclaw-plugin', 'openclaw-lark'])
+const LEGACY_PLUGIN_INSTALL_IDS = new Set(['feishu-openclaw-plugin', 'openclaw-lark'])
 const FEISHU_RELATED_PLUGIN_IDS = new Set([
-  BUILTIN_FEISHU_PLUGIN_ID,
   'feishu-openclaw-plugin',
+  'openclaw-lark',
   FEISHU_OFFICIAL_PLUGIN_ID,
 ])
 
@@ -75,50 +74,6 @@ function hasFeishuPluginContext(config: Record<string, any> | null | undefined):
   return false
 }
 
-function ensureBuiltinFeishuPluginDisabled(
-  config: Record<string, any>,
-  preserveBuiltInFeishuDisable: boolean
-): { changed: boolean; config: Record<string, any> } {
-  if (!preserveBuiltInFeishuDisable) {
-    return {
-      changed: false,
-      config,
-    }
-  }
-
-  const nextConfig = config
-  let changed = false
-
-  if (!hasOwnRecord(nextConfig.plugins)) {
-    nextConfig.plugins = {}
-    changed = true
-  }
-
-  const plugins = nextConfig.plugins as Record<string, any>
-  if (!hasOwnRecord(plugins.entries)) {
-    plugins.entries = {}
-    changed = true
-  }
-
-  const currentEntry = plugins.entries[BUILTIN_FEISHU_PLUGIN_ID]
-  const normalizedEntry = hasOwnRecord(currentEntry)
-    ? {
-        ...currentEntry,
-        enabled: false,
-      }
-    : { enabled: false }
-
-  if (!hasOwnRecord(currentEntry) || JSON.stringify(currentEntry) !== JSON.stringify(normalizedEntry)) {
-    plugins.entries[BUILTIN_FEISHU_PLUGIN_ID] = normalizedEntry
-    changed = true
-  }
-
-  return {
-    changed,
-    config: nextConfig,
-  }
-}
-
 export function sanitizeManagedPluginConfig(
   config: Record<string, any> | null | undefined,
   options: {
@@ -128,11 +83,9 @@ export function sanitizeManagedPluginConfig(
 ): { changed: boolean; config: Record<string, any> } {
   const nextConfig = cloneConfig(config)
   const blockedPluginIds = normalizeBlockedPluginIds(options.blockedPluginIds)
-  const preserveBuiltInFeishuDisable =
-    options.preserveBuiltInFeishuDisable ?? hasFeishuPluginContext(nextConfig)
   const plugins = hasOwnRecord(nextConfig.plugins) ? nextConfig.plugins : null
   if (!plugins) {
-    return ensureBuiltinFeishuPluginDisabled(nextConfig, preserveBuiltInFeishuDisable)
+    return { changed: false, config: nextConfig }
   }
 
   let changed = false
@@ -163,12 +116,9 @@ export function sanitizeManagedPluginConfig(
     }
   }
 
-  const disabledBuiltIn = ensureBuiltinFeishuPluginDisabled(nextConfig, preserveBuiltInFeishuDisable)
-  changed = changed || disabledBuiltIn.changed
-
   return {
     changed,
-    config: disabledBuiltIn.config,
+    config: nextConfig,
   }
 }
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -284,6 +284,10 @@ export const api = {
   skillsUpdate: (payload: { skillKey: string; enabled?: boolean; apiKey?: string }) =>
     ipcRenderer.invoke('skills:update', payload),
   skillsUninstall: (name: string) => ipcRenderer.invoke('skills:uninstall', name),
+  skillsWorkspaceList: (workspace: string) => ipcRenderer.invoke('skills:workspaceList', workspace),
+  skillsWorkspaceUninstall: (workspace: string, name: string) =>
+    ipcRenderer.invoke('skills:workspaceUninstall', workspace, name),
+  workspaceDelete: (workspace: string) => ipcRenderer.invoke('workspace:delete', workspace),
   skillsInstall: (name: string) => ipcRenderer.invoke('skills:install', name),
   clawhubSearch: (query: string, limit?: number) => ipcRenderer.invoke('clawhub:search', query, limit),
   clawhubInstall: (slug: string) => ipcRenderer.invoke('clawhub:install', slug),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import PairingCode from './pages/PairingCode'
 import Dashboard from './pages/Dashboard'
 import MainLayout from './components/MainLayout'
 import ChatPage from './pages/ChatPage'
+import AgentsPage from './pages/AgentsPage'
 import ChannelsPage from './pages/ChannelsPage'
 import ModelsPage from './pages/ModelsPage'
 import SettingsPage from './pages/SettingsPage'
@@ -723,6 +724,7 @@ function App() {
               path="/chat"
               element={<ChatPage enterSendMode={chatComposerEnterSendMode} />}
             />
+            <Route path="/agents" element={<AgentsPage />} />
             <Route path="/channels" element={<ChannelsPage />} />
             <Route path="/models" element={<ModelsPage />} />
             <Route path="/skills" element={<SkillsPage />} />

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -25,6 +25,16 @@ const NAV_ITEMS = [
     ),
   },
   {
+    to: '/agents',
+    label: 'Agent 管理',
+    tooltip: '管理和配置主/子 Agent 及其能力',
+    icon: (
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+      </svg>
+    ),
+  },
+  {
     to: '/channels',
     label: 'IM 渠道',
     tooltip: tooltips.layout.navigation.channelsExplain,

--- a/src/lib/feishu-multi-bot-routing.ts
+++ b/src/lib/feishu-multi-bot-routing.ts
@@ -170,118 +170,21 @@ function buildManagedFeishuAgentConfig(
 
 export function applyFeishuMultiBotIsolation(config: Record<string, any> | null): Record<string, any> {
   const next = cloneConfig(config)
-  const bots = extractFeishuRoutingBots(next)
 
   next.session = next.session && typeof next.session === 'object' && !Array.isArray(next.session) ? next.session : {}
   next.session.dmScope = FEISHU_DM_SCOPE
-
-  next.agents = next.agents && typeof next.agents === 'object' && !Array.isArray(next.agents) ? next.agents : {}
-  const currentAgents = Array.isArray(next.agents.list) ? next.agents.list : []
-  const expectedAgents = buildExpectedFeishuAgents(bots)
-  const expectedAgentIds = new Set(expectedAgents.map((agent) => agent.id))
-  const preservedAgents = currentAgents.filter(
-    (agent: Record<string, any>) => {
-      const agentId = normalizeText(agent?.id)
-      if (isResidualLegacyFeishuAgentId(agentId, expectedAgentIds)) {
-        return false
-      }
-      return !isFeishuManagedAgentId(agentId) || !expectedAgentIds.has(agentId)
-    }
-  )
-
-  next.agents.list = [
-    ...preservedAgents,
-    ...expectedAgents.map((expectedAgent) => buildManagedFeishuAgentConfig(expectedAgent, currentAgents)),
-  ]
-
-  const currentBindings = Array.isArray(next.bindings) ? next.bindings : []
-  const expectedBindings = buildExpectedFeishuBindings(bots)
-  const expectedAccountIds = new Set(expectedBindings.map((binding) => binding.match.accountId))
-  const preservedBindings = currentBindings.filter((binding) => {
-    if (
-      normalizeText(binding?.match?.channel) === 'feishu' &&
-      expectedAgentIds.has(getFeishuManagedAgentId(DEFAULT_FEISHU_ACCOUNT_ID)) &&
-      LEGACY_FEISHU_AGENT_IDS.includes(normalizeText(binding?.agentId))
-    ) {
-      return false
-    }
-    const accountId = normalizeText(binding?.match?.accountId)
-    return !(normalizeText(binding?.match?.channel) === 'feishu' && expectedAccountIds.has(accountId) && isFeishuManagedAgentId(binding?.agentId))
-  })
-
-  next.bindings = [
-    ...preservedBindings,
-    ...expectedBindings.map((expectedBinding) => {
-      const existingBinding = currentBindings.find((binding) =>
-        isMatchingFeishuBinding(binding as Record<string, any>, expectedBinding.match.accountId, expectedBinding.agentId)
-      )
-      return {
-        ...(existingBinding || {}),
-        agentId: expectedBinding.agentId,
-        match: {
-          ...((existingBinding as Record<string, any> | undefined)?.match || {}),
-          channel: 'feishu',
-          accountId: expectedBinding.match.accountId,
-        },
-      }
-    }),
-  ]
 
   return next
 }
 
 export function detectFeishuIsolationDrift(config: Record<string, any> | null): FeishuIsolationDrift {
-  const bots = extractFeishuRoutingBots(config)
-  const expectedAgents = buildExpectedFeishuAgents(bots)
-  const expectedBindings = buildExpectedFeishuBindings(bots)
-  const currentAgents = Array.isArray(config?.agents?.list) ? config?.agents?.list : []
-  const currentBindings = Array.isArray(config?.bindings) ? config?.bindings : []
-
-  const missingAgentIds: string[] = []
-  const workspaceMismatches: string[] = []
-  for (const expectedAgent of expectedAgents) {
-    const existingAgent = currentAgents.find(
-      (agent: Record<string, any>) => normalizeText(agent?.id) === expectedAgent.id
-    )
-    if (!existingAgent) {
-      missingAgentIds.push(expectedAgent.id)
-      continue
-    }
-    if (normalizeText(existingAgent.workspace) !== expectedAgent.workspace) {
-      workspaceMismatches.push(expectedAgent.id)
-    }
-  }
-
-  const missingBindingAccountIds: string[] = []
-  const conflictingBindingAccountIds: string[] = []
-  for (const expectedBinding of expectedBindings) {
-    const matchingBindings = currentBindings.filter(
-      (binding) =>
-        normalizeText(binding?.match?.channel) === 'feishu' &&
-        normalizeText(binding?.match?.accountId) === expectedBinding.match.accountId
-    )
-    if (!matchingBindings.some((binding) => normalizeText(binding?.agentId) === expectedBinding.agentId)) {
-      missingBindingAccountIds.push(expectedBinding.match.accountId)
-    }
-    if (matchingBindings.some((binding) => normalizeText(binding?.agentId) !== expectedBinding.agentId)) {
-      conflictingBindingAccountIds.push(expectedBinding.match.accountId)
-    }
-  }
-
-  const dmScopeCorrect = normalizeText(config?.session?.dmScope) === FEISHU_DM_SCOPE
-
   return {
-    needsRepair:
-      !dmScopeCorrect ||
-      missingAgentIds.length > 0 ||
-      missingBindingAccountIds.length > 0 ||
-      workspaceMismatches.length > 0 ||
-      conflictingBindingAccountIds.length > 0,
-    hasMultipleBots: bots.length > 1,
-    dmScopeCorrect,
-    missingAgentIds,
-    missingBindingAccountIds,
-    workspaceMismatches,
-    conflictingBindingAccountIds,
+    needsRepair: false,
+    hasMultipleBots: false,
+    dmScopeCorrect: true,
+    missingAgentIds: [],
+    missingBindingAccountIds: [],
+    workspaceMismatches: [],
+    conflictingBindingAccountIds: [],
   }
 }

--- a/src/pages/AgentManagement/AgentDetails.tsx
+++ b/src/pages/AgentManagement/AgentDetails.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Switch, Card, Text, Group, Divider, TextInput, Button, Badge, Loader, ActionIcon, Tooltip } from '@mantine/core'
+import { modals } from '@mantine/modals'
+import type { Agent } from './AgentList'
+
+interface AgentDetailsProps {
+  agent: Agent
+  onUpdate: (agent: Agent) => void
+  onDelete?: (agentId: string) => void
+}
+
+interface SkillInfo {
+  name: string
+  title?: string
+  description?: string
+  source?: string
+  path?: string
+}
+
+export function AgentDetails({ agent, onUpdate, onDelete }: AgentDetailsProps) {
+  const [workspace, setWorkspace] = useState(agent.workspace || '')
+  const [agentDir, setAgentDir] = useState(agent.agentDir || '')
+  const [model, setModel] = useState(agent.model || '')
+  const [feishuAppId, setFeishuAppId] = useState(agent.feishuAppId || '')
+  const [feishuAppSecret, setFeishuAppSecret] = useState(agent.feishuAppSecret || '')
+  const [sharedSkills, setSharedSkills] = useState<SkillInfo[]>([])
+  const [exclusiveSkills, setExclusiveSkills] = useState<SkillInfo[]>([])
+  const [loadingSkills, setLoadingSkills] = useState(false)
+
+  const loadSkills = useCallback(async () => {
+    setLoadingSkills(true)
+    try {
+      const sharedResult = await window.api.skillsList()
+      if (sharedResult.ok && sharedResult.stdout) {
+        const parsed = JSON.parse(sharedResult.stdout)
+        const list = Array.isArray(parsed) ? parsed : (parsed.skills || [])
+        setSharedSkills(list.filter((s: any) => s.source !== 'openclaw-workspace'))
+      }
+
+      if (agent.workspace) {
+        const exclusiveResult = await window.api.skillsWorkspaceList(agent.workspace)
+        if (exclusiveResult.ok && exclusiveResult.stdout) {
+          setExclusiveSkills(JSON.parse(exclusiveResult.stdout))
+        } else {
+          setExclusiveSkills([])
+        }
+      } else {
+        setExclusiveSkills([])
+      }
+    } catch (e) {
+      console.error('Failed to load skills:', e)
+    } finally {
+      setLoadingSkills(false)
+    }
+  }, [agent.workspace])
+
+  useEffect(() => {
+    setWorkspace(agent.workspace || '')
+    setAgentDir(agent.agentDir || '')
+    setModel(agent.model || '')
+    setFeishuAppId(agent.feishuAppId || '')
+    setFeishuAppSecret(agent.feishuAppSecret || '')
+    void loadSkills()
+  }, [agent, loadSkills])
+
+  const handleSave = () => {
+    const updatedAgent: Agent = {
+      ...agent,
+      workspace,
+      agentDir,
+      model,
+      feishuAppId,
+      feishuAppSecret,
+    }
+
+    onUpdate(updatedAgent)
+  }
+
+  const handleDeleteSharedSkill = (skillName: string) => {
+    modals.openConfirmModal({
+      title: '确认删除共享技能',
+      children: (
+        <Text size="sm">
+          您确定要删除共享技能 <b>{skillName}</b> 吗？删除后将无法恢复，所有 Agent 都将无法使用此技能。
+        </Text>
+      ),
+      labels: { confirm: '确认删除', cancel: '取消' },
+      confirmProps: { color: 'red' },
+      onConfirm: async () => {
+        try {
+          const res = await window.api.skillsUninstall(skillName)
+          if (res.ok) {
+            await loadSkills()
+          } else {
+            alert('删除失败: ' + res.stderr)
+          }
+        } catch (e) {
+          alert('删除失败: ' + String(e))
+        }
+      },
+    })
+  }
+
+  const handleDeleteExclusiveSkill = (skillName: string) => {
+    if (!agent.workspace) return
+    modals.openConfirmModal({
+      title: '确认删除专属技能',
+      children: (
+        <Text size="sm">
+          您确定要删除专属技能 <b>{skillName}</b> 吗？删除后将无法恢复。
+        </Text>
+      ),
+      labels: { confirm: '确认删除', cancel: '取消' },
+      confirmProps: { color: 'red' },
+      onConfirm: async () => {
+        try {
+          const res = await window.api.skillsWorkspaceUninstall(agent.workspace!, skillName)
+          if (res.ok) {
+            await loadSkills()
+          } else {
+            alert('删除失败: ' + res.stderr)
+          }
+        } catch (e) {
+          alert('删除失败: ' + String(e))
+        }
+      },
+    })
+  }
+
+  const handleDeleteAgent = () => {
+    if (!onDelete) return
+    modals.openConfirmModal({
+      title: '确认删除 Agent',
+      children: (
+        <Text size="sm">
+          您确定要删除 Agent <b>{agent.name || agent.id}</b> 吗？相关配置将被清理。此操作不可恢复。
+        </Text>
+      ),
+      labels: { confirm: '确认删除', cancel: '取消' },
+      confirmProps: { color: 'red' },
+      onConfirm: async () => {
+        if (agent.workspace) {
+          modals.openConfirmModal({
+            title: '是否同时删除工作区内容？',
+            children: (
+              <Text size="sm">
+                是否要同时从磁盘中删除该 Agent 关联的工作区目录 <b>{agent.workspace}</b>？<br />
+                如果您在其它地方也使用了此目录，请选择“保留工作区目录”。
+              </Text>
+            ),
+            labels: { confirm: '连同目录一起删除', cancel: '保留工作区目录' },
+            confirmProps: { color: 'red' },
+            onConfirm: async () => {
+              await window.api.workspaceDelete(agent.workspace!)
+              onDelete(agent.id)
+            },
+            onCancel: () => {
+              onDelete(agent.id)
+            },
+            onClose: () => {
+              onDelete(agent.id)
+            },
+          })
+        } else {
+          onDelete(agent.id)
+        }
+      },
+    })
+  }
+
+  return (
+    <Card padding="lg" withBorder shadow="sm" className="h-full flex flex-col">
+      <Group justify="space-between" mb="md">
+        <div>
+          <Text size="xl" fw={700}>{agent.name || agent.id}</Text>
+          <Text size="sm" c="dimmed" mt={4}>ID: {agent.id}</Text>
+        </div>
+        {agent.id !== 'main' && onDelete && (
+          <Button color="red" variant="light" size="sm" onClick={handleDeleteAgent}>
+            删除 Agent
+          </Button>
+        )}
+      </Group>
+      <Divider mb="lg" />
+
+      <div className="space-y-6 flex-1 overflow-y-auto pr-4">
+        {agent.id !== 'main' && (
+          <div>
+            <Text fw={500} size="md" mb="xs">调度设置</Text>
+            <Card padding="md" withBorder>
+              <Group justify="space-between" align="center" wrap="nowrap">
+                <div>
+                  <Text fw={500} size="sm">允许主 Agent 调度</Text>
+                  <Text size="xs" c="dimmed" mt={2}>开启后，主 Agent 可以将任务分发给该 Agent 执行</Text>
+                </div>
+                <Switch
+                  size="md"
+                  checked={agent.allowDispatch || false}
+                  onChange={(e) => onUpdate({ ...agent, allowDispatch: e.currentTarget.checked })}
+                />
+              </Group>
+            </Card>
+          </div>
+        )}
+
+        <div>
+          <Text fw={500} size="md" mb="xs">关联渠道</Text>
+          <Card padding="md" withBorder>
+            {agent.bindings && agent.bindings.length > 0 ? (
+              <Group gap="xs">
+                {agent.bindings.map((b: any, i: number) => {
+                  const channelStr = b.match?.channel ? b.match.channel : 'Unknown'
+                  const accountStr = b.match?.accountId ? ` (${b.match.accountId})` : ''
+                  const peerStr = b.match?.peer?.id ? ` (群/单聊: ${b.match.peer.id})` : ''
+                  return (
+                    <Badge key={i} color="indigo" variant="light">
+                      {channelStr}{accountStr}{peerStr}
+                    </Badge>
+                  )
+                })}
+              </Group>
+            ) : (
+              <Text size="sm" c="dimmed">暂未绑定任何渠道</Text>
+            )}
+          </Card>
+        </div>
+
+        <div>
+          <Text fw={500} size="md" mb="xs">技能管理</Text>
+          <Card padding="md" withBorder>
+            {loadingSkills ? (
+              <Group justify="center" py="md"><Loader size="sm" /></Group>
+            ) : (
+              <div className="space-y-4">
+                <div>
+                  <Text size="sm" fw={500} mb="xs">专属技能 (当前 Agent Workspace)</Text>
+                  {exclusiveSkills.length > 0 ? (
+                    <div className="space-y-2">
+                      {exclusiveSkills.map((skill, idx) => (
+                        <Card key={idx} padding="sm" withBorder shadow="none">
+                          <Group justify="space-between" wrap="nowrap">
+                            <div className="flex-1 min-w-0">
+                              <Text size="sm" fw={500} truncate>{skill.title || skill.name}</Text>
+                              <Text size="xs" c="dimmed" truncate>{skill.description || '暂无描述'}</Text>
+                            </div>
+                            <Tooltip label="删除该专属技能">
+                              <ActionIcon color="red" variant="light" onClick={() => handleDeleteExclusiveSkill(skill.name)}>
+                                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                </svg>
+                              </ActionIcon>
+                            </Tooltip>
+                          </Group>
+                        </Card>
+                      ))}
+                    </div>
+                  ) : (
+                    <Text size="sm" c="dimmed">无专属技能</Text>
+                  )}
+                </div>
+
+                <div>
+                  <Text size="sm" fw={500} mb="xs">共享技能 (~/.openclaw/skills)</Text>
+                  {sharedSkills.length > 0 ? (
+                    <div className="space-y-2">
+                      {sharedSkills.map((skill, idx) => (
+                        <Card key={idx} padding="sm" withBorder shadow="none">
+                          <Group justify="space-between" wrap="nowrap">
+                            <div className="flex-1 min-w-0">
+                              <Group gap="xs">
+                                <Text size="sm" fw={500} truncate>{skill.title || skill.name}</Text>
+                                {skill.source === 'openclaw-bundled' && <Badge size="xs" variant="light">内置</Badge>}
+                              </Group>
+                              <Text size="xs" c="dimmed" truncate>{skill.description || '暂无描述'}</Text>
+                            </div>
+                            {agent.id === 'main' && skill.source !== 'openclaw-bundled' && (
+                              <Tooltip label="删除该共享技能">
+                                <ActionIcon color="red" variant="light" onClick={() => handleDeleteSharedSkill(skill.name)}>
+                                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                  </svg>
+                                </ActionIcon>
+                              </Tooltip>
+                            )}
+                          </Group>
+                        </Card>
+                      ))}
+                    </div>
+                  ) : (
+                    <Text size="sm" c="dimmed">无共享技能</Text>
+                  )}
+                </div>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        <div>
+          <Text fw={500} size="md" mb="xs">基础配置</Text>
+          <Card padding="md" withBorder className="space-y-4">
+            <TextInput
+              label="模型 (Model)"
+              placeholder="例如: volcengine-plan/doubao-seed-2.0-pro"
+              value={model}
+              onChange={(e) => setModel(e.currentTarget.value)}
+              description="配置该 Agent 优先使用的大语言模型"
+            />
+            <TextInput
+              label="工作区 (Workspace)"
+              placeholder="工作区路径"
+              value={workspace}
+              onChange={(e) => setWorkspace(e.currentTarget.value)}
+              description="Agent 执行任务时使用的本地工作目录"
+            />
+            <TextInput
+              label="Agent 目录 (AgentDir)"
+              placeholder="Agent 配置文件所在目录"
+              value={agentDir}
+              onChange={(e) => setAgentDir(e.currentTarget.value)}
+              description="存储 Agent 提示词、技能配置的目录"
+            />
+          </Card>
+        </div>
+
+        <div>
+          <Text fw={500} size="md" mb="xs">飞书渠道配置 (Feishu Channel)</Text>
+          <Card padding="md" withBorder className="space-y-4">
+            <TextInput
+              label="App ID"
+              placeholder="cli_..."
+              value={feishuAppId}
+              onChange={(e) => setFeishuAppId(e.currentTarget.value)}
+              description="飞书机器人的 App ID"
+            />
+            <TextInput
+              label="App Secret"
+              placeholder="输入应用密钥"
+              type="password"
+              value={feishuAppSecret}
+              onChange={(e) => setFeishuAppSecret(e.currentTarget.value)}
+              description="飞书机器人的 App Secret"
+            />
+            <div className="pt-2">
+              <Button onClick={handleSave}>保存配置</Button>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/pages/AgentManagement/AgentList.tsx
+++ b/src/pages/AgentManagement/AgentList.tsx
@@ -1,0 +1,108 @@
+import { Card, Text, ScrollArea, Group, Badge, Button, TextInput, Stack } from '@mantine/core'
+import { modals } from '@mantine/modals'
+
+export interface Agent {
+  id: string
+  name?: string
+  allowDispatch?: boolean
+  bindings?: any[]
+  feishuAppId?: string
+  feishuAppSecret?: string
+  [key: string]: any
+}
+
+interface AgentListProps {
+  agents: Agent[]
+  selectedId?: string | null
+  onSelect: (id: string) => void
+  onCreateAgent?: (agent: Partial<Agent>) => Promise<void> | void
+}
+
+export function AgentList({ agents, selectedId, onSelect, onCreateAgent }: AgentListProps) {
+  const handleCreateClick = () => {
+    if (!onCreateAgent) return
+    let newId = ''
+    modals.open({
+      title: '新建 Agent',
+      children: (
+        <Stack>
+          <TextInput
+            label="Agent ID"
+            placeholder="例如: designer, data-analyst"
+            required
+            onChange={(e) => {
+              newId = e.currentTarget.value
+            }}
+            description="只能包含字母、数字和连字符，作为唯一标识"
+          />
+          <Button fullWidth onClick={async () => {
+            if (!newId.trim() || !/^[a-zA-Z0-9-]+$/.test(newId.trim())) {
+              alert('ID 格式不正确')
+              return
+            }
+            if (agents.find(a => a.id === newId.trim())) {
+              alert('ID 已存在')
+              return
+            }
+            await onCreateAgent({ id: newId.trim() })
+            modals.closeAll()
+          }}>
+            创建
+          </Button>
+        </Stack>
+      ),
+    })
+  }
+
+  return (
+    <div className="w-[300px] flex-shrink-0">
+      <ScrollArea h="calc(100vh - 200px)" type="auto">
+        <div className="space-y-3 pr-4">
+          {onCreateAgent && (
+            <Button variant="light" color="blue" onClick={handleCreateClick} fullWidth>
+              + 新建 Agent
+            </Button>
+          )}
+          {agents.length === 0 ? (
+            <Card padding="xl" withBorder className="text-center">
+              <Text size="sm" c="dimmed">
+                暂无 Agent
+              </Text>
+            </Card>
+          ) : (
+            agents.map((agent) => {
+              const isSelected = selectedId === agent.id
+              return (
+                <Card
+                  key={agent.id}
+                  padding="md"
+                  withBorder
+                  className="cursor-pointer transition-colors duration-200"
+                  style={{
+                    backgroundColor: isSelected ? 'var(--mantine-color-blue-light)' : undefined,
+                    borderColor: isSelected ? 'var(--mantine-color-blue-filled)' : undefined,
+                  }}
+                  onClick={() => onSelect(agent.id)}
+                >
+                  <Group justify="space-between" align="flex-start" wrap="nowrap">
+                    <div className="overflow-hidden">
+                      <Text fw={600} truncate>{agent.name || agent.id}</Text>
+                      <Text size="xs" c="dimmed" mt={4} truncate>
+                        ID: {agent.id}
+                      </Text>
+                    </div>
+                    {agent.allowDispatch && (
+                      <Badge size="xs" color="blue" variant="light" className="flex-shrink-0">
+                        可调度
+                      </Badge>
+                    )}
+                  </Group>
+                </Card>
+              )
+            })
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/pages/AgentManagement/AgentManagement.tsx
+++ b/src/pages/AgentManagement/AgentManagement.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react'
+import { AgentList, type Agent } from './AgentList'
+import { AgentDetails } from './AgentDetails'
+
+export interface AgentManagementProps {
+  agents: Agent[]
+  onUpdateAgent: (agent: Agent) => void
+  onCreateAgent?: (agent: Partial<Agent>) => Promise<string | undefined>
+  onDeleteAgent?: (agentId: string) => void
+}
+
+export function AgentManagement({ agents, onUpdateAgent, onCreateAgent, onDeleteAgent }: AgentManagementProps) {
+  const [selectedId, setSelectedId] = useState<string | undefined>(agents[0]?.id)
+
+  useEffect(() => {
+    if (!selectedId && agents.length > 0) {
+      setSelectedId(agents[0].id)
+    }
+  }, [agents, selectedId])
+
+  const selectedAgent = agents.find((a) => a.id === selectedId)
+
+  const handleCreate = async (agentData: Partial<Agent>) => {
+    if (!onCreateAgent) return
+    const newId = await onCreateAgent(agentData)
+    if (newId) {
+      setSelectedId(newId)
+    }
+  }
+
+  return (
+    <div className="p-6 h-full">
+      <div className="flex gap-6 h-full">
+        <AgentList agents={agents} selectedId={selectedId} onSelect={setSelectedId} onCreateAgent={onCreateAgent ? handleCreate : undefined} />
+        <div className="flex-1 min-w-0">
+          {selectedAgent ? (
+            <AgentDetails agent={selectedAgent} onUpdate={onUpdateAgent} onDelete={onDeleteAgent} />
+          ) : (
+            <div className="flex items-center justify-center h-full text-gray-500">请选择或创建一个 Agent</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react'
+import { Loader, Alert, Group, Text } from '@mantine/core'
+import { AgentManagement } from './AgentManagement/AgentManagement'
+import type { Agent } from './AgentManagement/AgentList'
+
+export default function AgentsPage() {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const fetchAgents = async () => {
+    try {
+      setError('')
+      const config = await window.api.readConfig()
+      if (config && config.agents && Array.isArray(config.agents.list)) {
+        const list = config.agents.list
+        const mainAgent = list.find((a: any) => a.id === 'main')
+        const allowedAgents = mainAgent?.subagents?.allowAgents || []
+
+        const mappedAgents = list.map((a: any) => {
+          const boundBindings = (config.bindings || []).filter((b: any) => b.agentId === a.id)
+          const workspace = a.id === 'main' ? config.agents?.defaults?.workspace || '' : a.workspace
+
+          let feishuAppId = ''
+          let feishuAppSecret = ''
+          if (config.channels?.feishu?.accounts?.[a.id]) {
+            feishuAppId = config.channels.feishu.accounts[a.id].appId || ''
+            feishuAppSecret = config.channels.feishu.accounts[a.id].appSecret || ''
+          }
+
+          return {
+            ...a,
+            workspace,
+            allowDispatch: allowedAgents.includes(a.id),
+            bindings: boundBindings,
+            feishuAppId,
+            feishuAppSecret,
+          }
+        })
+        setAgents(mappedAgents)
+      } else {
+        setAgents([])
+      }
+    } catch (e) {
+      setError('读取配置失败: ' + (e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void fetchAgents()
+  }, [])
+
+  const handleUpdateAgent = async (agent: Agent) => {
+    try {
+      const config = await window.api.readConfig()
+      if (!config) return
+
+      const beforeConfig = JSON.parse(JSON.stringify(config))
+      const nextConfig = JSON.parse(JSON.stringify(config))
+
+      if (!nextConfig.agents) nextConfig.agents = { list: [] }
+      const list = nextConfig.agents.list || []
+
+      let mainAgent = list.find((a: any) => a.id === 'main')
+      if (!mainAgent) {
+        mainAgent = { id: 'main', subagents: { allowAgents: [] } }
+        list.push(mainAgent)
+      }
+
+      if (!mainAgent.subagents) mainAgent.subagents = { allowAgents: [] }
+      if (!mainAgent.subagents.allowAgents) mainAgent.subagents.allowAgents = []
+
+      const allowedAgents = new Set<string>(mainAgent.subagents.allowAgents)
+      if (agent.allowDispatch) {
+        allowedAgents.add(agent.id)
+      } else {
+        allowedAgents.delete(agent.id)
+      }
+      mainAgent.subagents.allowAgents = Array.from(allowedAgents)
+
+      if (agent.id === 'main') {
+        if (!nextConfig.agents.defaults) nextConfig.agents.defaults = {}
+        nextConfig.agents.defaults.workspace = agent.workspace
+      }
+
+      const agentToSave = { ...agent }
+      delete agentToSave.allowDispatch
+      const newBindings = agentToSave.bindings
+      delete agentToSave.bindings
+      const feishuAppId = agentToSave.feishuAppId
+      const feishuAppSecret = agentToSave.feishuAppSecret
+      delete agentToSave.feishuAppId
+      delete agentToSave.feishuAppSecret
+
+      if (feishuAppId || feishuAppSecret) {
+        if (!nextConfig.channels) nextConfig.channels = {}
+        if (!nextConfig.channels.feishu) nextConfig.channels.feishu = { enabled: true, connectionMode: 'websocket', domain: 'feishu', requireMention: true, accounts: {} }
+        if (!nextConfig.channels.feishu.accounts) nextConfig.channels.feishu.accounts = {}
+        if (!nextConfig.channels.feishu.accounts[agent.id]) nextConfig.channels.feishu.accounts[agent.id] = {}
+
+        if (feishuAppId) nextConfig.channels.feishu.accounts[agent.id].appId = feishuAppId
+        if (feishuAppSecret) nextConfig.channels.feishu.accounts[agent.id].appSecret = feishuAppSecret
+      } else if (nextConfig.channels?.feishu?.accounts?.[agent.id]) {
+        delete nextConfig.channels.feishu.accounts[agent.id].appId
+        delete nextConfig.channels.feishu.accounts[agent.id].appSecret
+      }
+
+      if (agent.id === 'main') {
+        delete agentToSave.workspace
+      }
+
+      const index = list.findIndex((a: any) => a.id === agent.id)
+      if (index >= 0) {
+        list[index] = { ...list[index], ...agentToSave }
+      } else {
+        list.push(agentToSave)
+      }
+      nextConfig.agents.list = list
+
+      if (newBindings !== undefined) {
+        const otherBindings = (nextConfig.bindings || []).filter((b: any) => b.agentId !== agent.id)
+        const agentBindings = newBindings.map((b: any) => ({ ...b, agentId: agent.id }))
+        nextConfig.bindings = [...otherBindings, ...agentBindings]
+      }
+
+      const writeResult = await window.api.applyConfigPatchGuarded({
+        beforeConfig,
+        afterConfig: nextConfig,
+        reason: 'unknown',
+      })
+      if (!writeResult.ok) throw new Error(writeResult.message)
+      await fetchAgents()
+    } catch (e) {
+      setError('更新 Agent 失败: ' + (e as Error).message)
+    }
+  }
+
+  const handleCreateAgent = async (newAgent: Partial<Agent>): Promise<string | undefined> => {
+    try {
+      const config = await window.api.readConfig()
+      if (!config) return undefined
+
+      const beforeConfig = JSON.parse(JSON.stringify(config))
+      const nextConfig = JSON.parse(JSON.stringify(config))
+
+      if (!nextConfig.agents) nextConfig.agents = { list: [] }
+      const list = nextConfig.agents.list || []
+
+      const agentToSave = {
+        id: newAgent.id!,
+        model: config.agents?.defaults?.model || '',
+        workspace: config.agents?.defaults?.workspace
+          ? config.agents.defaults.workspace.replace(/workspace(-main)?$/, `workspace-${newAgent.id}`)
+          : `~/.openclaw/workspace-${newAgent.id}`,
+      }
+
+      list.push(agentToSave)
+      nextConfig.agents.list = list
+
+      const writeResult = await window.api.applyConfigPatchGuarded({
+        beforeConfig,
+        afterConfig: nextConfig,
+        reason: 'unknown',
+      })
+      if (!writeResult.ok) throw new Error(writeResult.message)
+      await fetchAgents()
+      return newAgent.id
+    } catch (e) {
+      setError('新建 Agent 失败: ' + (e as Error).message)
+      return undefined
+    }
+  }
+
+  const handleDeleteAgent = async (agentId: string) => {
+    try {
+      const config = await window.api.readConfig()
+      if (!config) return
+
+      const beforeConfig = JSON.parse(JSON.stringify(config))
+      const nextConfig = JSON.parse(JSON.stringify(config))
+
+      if (!nextConfig.agents) nextConfig.agents = { list: [] }
+      const list = nextConfig.agents.list || []
+
+      nextConfig.agents.list = list.filter((a: any) => a.id !== agentId)
+
+      const mainAgent = nextConfig.agents.list.find((a: any) => a.id === 'main')
+      if (mainAgent?.subagents?.allowAgents) {
+        mainAgent.subagents.allowAgents = mainAgent.subagents.allowAgents.filter((id: string) => id !== agentId)
+      }
+
+      if (nextConfig.bindings) {
+        nextConfig.bindings = nextConfig.bindings.filter((b: any) => b.agentId !== agentId)
+      }
+
+      const writeResult = await window.api.applyConfigPatchGuarded({
+        beforeConfig,
+        afterConfig: nextConfig,
+        reason: 'unknown',
+      })
+      if (!writeResult.ok) throw new Error(writeResult.message)
+      await fetchAgents()
+    } catch (e) {
+      setError('删除 Agent 失败: ' + (e as Error).message)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader size="lg" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6 h-full flex flex-col">
+      <Group justify="space-between">
+        <div>
+          <Text size="xl" fw={700}>Agent 管理</Text>
+          <Text size="sm" c="dimmed" mt={4}>
+            管理主/子 Agent 的调用权限、技能、工作区及关联渠道配置
+          </Text>
+        </div>
+      </Group>
+
+      {error && (
+        <Alert color="red" title="错误" onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+
+      <div className="flex-1 min-h-0 bg-transparent rounded-md border app-border">
+        <AgentManagement
+          agents={agents}
+          onUpdateAgent={handleUpdateAgent}
+          onCreateAgent={handleCreateAgent}
+          onDeleteAgent={handleDeleteAgent}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ChannelIntegration/ChannelCard.tsx
+++ b/src/pages/ChannelIntegration/ChannelCard.tsx
@@ -1,0 +1,63 @@
+import { Switch, Card, Text, Group, Badge } from '@mantine/core'
+
+export interface Channel {
+  id: string
+  name?: string
+  platform?: string
+  enabled?: boolean
+  plugins?: Record<string, { enabled: boolean; [key: string]: any }>
+  [key: string]: any
+}
+
+interface ChannelCardProps {
+  channel: Channel
+  onUpdatePlugin: (channelId: string, pluginId: string, enabled: boolean) => void
+}
+
+export function ChannelCard({ channel, onUpdatePlugin }: ChannelCardProps) {
+  return (
+    <Card padding="lg" withBorder>
+      <Group justify="space-between" align="flex-start" mb="md">
+        <div>
+          <Group gap="xs">
+            <Text fw={600} size="lg">{channel.name || channel.id}</Text>
+            {channel.platform && (
+              <Badge variant="light" size="sm">{channel.platform}</Badge>
+            )}
+          </Group>
+          <Text size="xs" c="dimmed" mt={4}>ID: {channel.id}</Text>
+        </div>
+        <Badge variant="light" size="sm" color={channel.enabled ? 'teal' : 'gray'}>
+          {channel.enabled ? '已启用' : '已禁用'}
+        </Badge>
+      </Group>
+
+      <div className="mt-4 border-t border-gray-100 pt-4">
+        <Text fw={500} size="sm" mb="md">渠道插件</Text>
+        <div className="space-y-3">
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <div>
+              <Text fw={500} size="sm">在线工单收集</Text>
+              <Text size="xs" c="dimmed" mt={2}>开启后可在线收集用户反馈并转化为工单</Text>
+            </div>
+            <Switch
+              checked={channel.plugins?.['online-issue']?.enabled || false}
+              onChange={(e) => onUpdatePlugin(channel.id, 'online-issue', e.currentTarget.checked)}
+            />
+          </Group>
+
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <div>
+              <Text fw={500} size="sm">自动修复</Text>
+              <Text size="xs" c="dimmed" mt={2}>遇到运行异常时尝试自动恢复</Text>
+            </div>
+            <Switch
+              checked={channel.plugins?.['auto-repair']?.enabled || false}
+              onChange={(e) => onUpdatePlugin(channel.id, 'auto-repair', e.currentTarget.checked)}
+            />
+          </Group>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/pages/ChannelIntegration/ChannelIntegration.tsx
+++ b/src/pages/ChannelIntegration/ChannelIntegration.tsx
@@ -1,0 +1,33 @@
+import { ScrollArea, Card, Text } from '@mantine/core'
+import { ChannelCard, type Channel } from './ChannelCard'
+
+export interface ChannelIntegrationProps {
+  channels: Channel[]
+  onUpdatePlugin: (channelId: string, pluginId: string, enabled: boolean) => void
+}
+
+export function ChannelIntegration({ channels, onUpdatePlugin }: ChannelIntegrationProps) {
+  return (
+    <div className="p-6 h-full">
+      <ScrollArea h="calc(100vh - 200px)" type="auto">
+        <div className="space-y-4 pr-4">
+          {channels.length === 0 ? (
+            <Card padding="xl" withBorder className="text-center">
+              <Text size="sm" c="dimmed">
+                暂无配置的 IM 渠道
+              </Text>
+            </Card>
+          ) : (
+            channels.map((channel) => (
+              <ChannelCard
+                key={channel.id}
+                channel={channel}
+                onUpdatePlugin={onUpdatePlugin}
+              />
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/pages/ChannelsPage.tsx
+++ b/src/pages/ChannelsPage.tsx
@@ -12,7 +12,6 @@ import {
   type ChannelPairingTarget,
 } from './channels-page-utils'
 import {
-  listFeishuBots,
   listResidualLegacyFeishuAgentIds,
   removeFeishuBotConfigForPluginState,
   sanitizeFeishuPluginConfig,
@@ -211,59 +210,28 @@ export default function ChannelsPage() {
 
       if (normalizedConfig.channels?.feishu) {
         const feishuPluginStatus = await loadManagedPluginStatus('feishu')
-        const feishuBots = listFeishuBots(normalizedConfig)
-        try {
-          const feishuPairingStatus = await window.api.pairingFeishuStatus(feishuBots.map((bot) => bot.accountId))
-          for (const bot of feishuBots) {
-            const pairing = feishuPairingStatus[bot.accountId]
-            const pairedCount = Number(pairing?.pairedCount || 0)
-            channelList.push({
-              id: `feishu:${bot.accountId}`,
-              channelId: 'feishu',
-              configChannelId: 'feishu',
-              name: bot.name,
-              accountName: bot.name,
-              platform: 'feishu',
-              enabled: bot.enabled,
-              credentials: {},
-              pairingRequired: true,
-              pairingState: pairedCount > 0 ? 'paired' : 'pending',
-              pairedCount,
-              pairingUsers: pairing?.pairedUsers || [],
-              pairingAccountId: bot.accountId,
-              agentId: bot.agentId,
-              isFeishuBot: true,
-              runtimeState: feishuRuntimeStatus[bot.accountId]?.runtimeState,
-              runtimeSummary: feishuRuntimeStatus[bot.accountId]?.summary,
-              runtimeIssues: feishuRuntimeStatus[bot.accountId]?.issues || [],
-              pluginStatus: feishuPluginStatus,
-            })
-          }
-        } catch {
-          for (const bot of feishuBots) {
-            channelList.push({
-              id: `feishu:${bot.accountId}`,
-              channelId: 'feishu',
-              configChannelId: 'feishu',
-              name: bot.name,
-              accountName: bot.name,
-              platform: 'feishu',
-              enabled: bot.enabled,
-              credentials: {},
-              pairingRequired: true,
-              pairingState: 'pending',
-              pairedCount: 0,
-              pairingUsers: [],
-              pairingAccountId: bot.accountId,
-              agentId: bot.agentId,
-              isFeishuBot: true,
-              runtimeState: feishuRuntimeStatus[bot.accountId]?.runtimeState,
-              runtimeSummary: feishuRuntimeStatus[bot.accountId]?.summary,
-              runtimeIssues: feishuRuntimeStatus[bot.accountId]?.issues || [],
-              pluginStatus: feishuPluginStatus,
-            })
-          }
-        }
+
+        channelList.push({
+          id: `feishu`,
+          channelId: 'feishu',
+          configChannelId: 'feishu',
+          name: '飞书 (Feishu)',
+          accountName: '飞书 (Feishu)',
+          platform: 'feishu',
+          enabled: normalizedConfig.channels.feishu.enabled !== false,
+          credentials: {},
+          pairingRequired: false,
+          pairingState: 'not_required',
+          pairedCount: 0,
+          pairingUsers: [],
+          pairingAccountId: '',
+          agentId: '',
+          isFeishuBot: true,
+          runtimeState: feishuRuntimeStatus['main']?.runtimeState || feishuRuntimeStatus['default']?.runtimeState,
+          runtimeSummary: feishuRuntimeStatus['main']?.summary || feishuRuntimeStatus['default']?.summary,
+          runtimeIssues: feishuRuntimeStatus['main']?.issues || feishuRuntimeStatus['default']?.issues || [],
+          pluginStatus: feishuPluginStatus,
+        })
       }
 
       const weixinConfig = config.channels?.['openclaw-weixin']
@@ -603,23 +571,18 @@ export default function ChannelsPage() {
         nextConfig.channels = {}
       }
 
-      if (channel.channelId === 'feishu' && channel.pairingAccountId) {
+      if (channel.isFeishuBot) {
         if (!nextConfig.channels.feishu || typeof nextConfig.channels.feishu !== 'object') {
-          throw new Error('未找到飞书渠道配置')
+          nextConfig.channels.feishu = { enabled: nextEnabled, accounts: {} }
+        } else {
+          nextConfig.channels.feishu.enabled = nextEnabled
         }
 
-        if (channel.pairingAccountId === 'default') {
-          nextConfig.channels.feishu.enabled = nextEnabled
-        } else {
-          const accounts = nextConfig.channels.feishu.accounts as Record<string, any> | undefined
-          if (!accounts || typeof accounts !== 'object' || !accounts[channel.pairingAccountId]) {
-            throw new Error(`未找到飞书 Bot 账号: ${channel.pairingAccountId}`)
-          }
-          const accountConfig = accounts[channel.pairingAccountId]
-          if (!accountConfig || typeof accountConfig !== 'object' || Array.isArray(accountConfig)) {
-            throw new Error(`飞书 Bot 账号配置异常: ${channel.pairingAccountId}`)
-          }
-          accountConfig.enabled = nextEnabled
+        if (!nextConfig.plugins) nextConfig.plugins = {}
+        if (!nextConfig.plugins.entries) nextConfig.plugins.entries = {}
+        nextConfig.plugins.entries['feishu'] = {
+          ...(nextConfig.plugins.entries['feishu'] || {}),
+          enabled: nextEnabled,
         }
       } else if (channel.channelId === 'openclaw-weixin' && channel.pairingAccountId) {
         const existingWeixinChannel = nextConfig.channels['openclaw-weixin'] as Record<string, any> | undefined
@@ -826,7 +789,9 @@ export default function ChannelsPage() {
                               插件状态：{channel.pluginStatus.summary}
                             </Text>
                             <Group gap="xs">
-                              {channel.pluginStatus.stages.map((stage) => (
+                              {channel.pluginStatus.stages
+                                .filter(stage => stage.id === 'installed' || stage.id === 'registered')
+                                .map((stage) => (
                                 <Badge
                                   key={`${channel.id}:${stage.id}`}
                                   variant="light"

--- a/src/pages/feishu-bots.ts
+++ b/src/pages/feishu-bots.ts
@@ -2,12 +2,11 @@ import { DEFAULT_FEISHU_CHANNEL_SETTINGS } from '../lib/openclaw-channel-registr
 import {
   applyFeishuMultiBotIsolation,
   detectFeishuIsolationDrift,
-  getFeishuManagedAgentId,
 } from '../lib/feishu-multi-bot-routing'
 
 const DEFAULT_FEISHU_ACCOUNT_ID = 'default'
-const BUILTIN_FEISHU_PLUGIN_ID = 'feishu'
-const LEGACY_FEISHU_PLUGIN_IDS = ['feishu-openclaw-plugin']
+export const FEISHU_OFFICIAL_PLUGIN_ID = 'feishu'
+const LEGACY_FEISHU_PLUGIN_IDS = ['feishu-openclaw-plugin', 'openclaw-lark']
 const LEGACY_FEISHU_AGENT_IDS = ['feishu-bot']
 
 export interface FeishuBotItem {
@@ -81,7 +80,7 @@ export function listFeishuBots(config: Record<string, any> | null): FeishuBotIte
       appId: defaultAppId,
       enabled: feishu.enabled !== false,
       isDefault: true,
-      agentId: getFeishuManagedAgentId(DEFAULT_FEISHU_ACCOUNT_ID),
+        agentId: DEFAULT_FEISHU_ACCOUNT_ID,
     })
   }
 
@@ -97,7 +96,7 @@ export function listFeishuBots(config: Record<string, any> | null): FeishuBotIte
         appId,
         enabled: account.enabled !== false,
         isDefault: false,
-        agentId: getFeishuManagedAgentId(accountId),
+        agentId: accountId,
       })
     }
   }
@@ -227,31 +226,21 @@ export function sanitizeFeishuPluginConfig(config: Record<string, any> | null): 
 
   if (Array.isArray(next.plugins.allow)) {
     next.plugins.allow = next.plugins.allow.filter(
-      (item: unknown) => ![BUILTIN_FEISHU_PLUGIN_ID, ...LEGACY_FEISHU_PLUGIN_IDS].includes(String(item || '').trim())
+      (item: unknown) => !LEGACY_FEISHU_PLUGIN_IDS.includes(String(item || '').trim())
     )
   }
 
-  if (next.plugins.entries && typeof next.plugins.entries === 'object') {
-    for (const legacyId of LEGACY_FEISHU_PLUGIN_IDS) {
-      delete next.plugins.entries[legacyId]
-    }
+  if (next.plugins?.entries && typeof next.plugins.entries === 'object') {
+    const entries = { ...next.plugins.entries }
+    LEGACY_FEISHU_PLUGIN_IDS.forEach(id => delete entries[id])
+    entries[FEISHU_OFFICIAL_PLUGIN_ID] = { ...(entries[FEISHU_OFFICIAL_PLUGIN_ID] || {}), enabled: true }
+    next.plugins.entries = entries
   }
 
-  if (!hasOwnRecord(next.plugins.entries)) {
-    next.plugins.entries = {}
-  }
-  const currentBuiltInEntry = next.plugins.entries[BUILTIN_FEISHU_PLUGIN_ID]
-  next.plugins.entries[BUILTIN_FEISHU_PLUGIN_ID] = hasOwnRecord(currentBuiltInEntry)
-    ? {
-        ...currentBuiltInEntry,
-        enabled: false,
-      }
-    : { enabled: false }
-
-  if (next.plugins.installs && typeof next.plugins.installs === 'object') {
-    for (const legacyId of [BUILTIN_FEISHU_PLUGIN_ID, ...LEGACY_FEISHU_PLUGIN_IDS]) {
-      delete next.plugins.installs[legacyId]
-    }
+  if (next.plugins?.installs && typeof next.plugins.installs === 'object') {
+    const installs = { ...next.plugins.installs }
+    LEGACY_FEISHU_PLUGIN_IDS.forEach(id => delete installs[id])
+    next.plugins.installs = installs
   }
 
   return next
@@ -261,15 +250,17 @@ export function stripFeishuOfficialPluginConfig(config: Record<string, any> | nu
   const next = sanitizeFeishuPluginConfig(config)
   if (Array.isArray(next.plugins?.allow)) {
     next.plugins.allow = next.plugins.allow.filter(
-      (item: unknown) => String(item || '').trim() !== 'openclaw-lark'
+      (item: unknown) => String(item || '').trim() !== FEISHU_OFFICIAL_PLUGIN_ID
     )
   }
   if (next.plugins?.entries && typeof next.plugins.entries === 'object') {
-    const { ['openclaw-lark']: _removedEntry, ...entries } = next.plugins.entries
+    const entries = { ...next.plugins.entries }
+    delete entries[FEISHU_OFFICIAL_PLUGIN_ID]
     next.plugins.entries = entries
   }
   if (next.plugins?.installs && typeof next.plugins.installs === 'object') {
-    const { ['openclaw-lark']: _removedInstall, ...installs } = next.plugins.installs
+    const installs = { ...next.plugins.installs }
+    delete installs[FEISHU_OFFICIAL_PLUGIN_ID]
     next.plugins.installs = installs
   }
   return next

--- a/src/shared/official-channel-status-view.ts
+++ b/src/shared/official-channel-status-view.ts
@@ -9,7 +9,8 @@ export function getOfficialChannelStageLabel(
   if (stageId === 'installed') return '已安装'
   if (stageId === 'registered') return '已注册'
   if (stageId === 'loaded') return '已加载'
-  return '已就绪'
+  if (stageId === 'ready') return '已就绪'
+  return ''
 }
 
 export function getOfficialChannelStageStateLabel(

--- a/src/shared/openclaw-version-policy.ts
+++ b/src/shared/openclaw-version-policy.ts
@@ -2,8 +2,8 @@ import type { OpenClawInstallSource } from './openclaw-phase1'
 import { compareLooseVersions } from './openclaw-phase1'
 
 export const MIN_SUPPORTED_OPENCLAW_VERSION = '2026.3.22'
-export const MAX_SUPPORTED_OPENCLAW_VERSION = '2026.3.24'
-export const PINNED_OPENCLAW_VERSION = '2026.3.24'
+export const MAX_SUPPORTED_OPENCLAW_VERSION = '2026.3.31'
+export const PINNED_OPENCLAW_VERSION = '2026.3.31'
 
 export type OpenClawVersionPolicyState =
   | 'below_min'

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1973,6 +1973,9 @@ interface ElectronApi {
     apiKey?: string
   }) => Promise<{ ok: boolean; error?: string }>
   skillsUninstall: (name: string) => Promise<CliResult>
+  skillsWorkspaceList: (workspace: string) => Promise<CliResult>
+  skillsWorkspaceUninstall: (workspace: string, name: string) => Promise<CliResult>
+  workspaceDelete: (workspace: string) => Promise<CliResult>
   skillsInstall: (name: string) => Promise<CliResult>
   clawhubSearch: (query: string, limit?: number) => Promise<{ ok: boolean; skills: { slug: string; name: string; score: number }[]; error?: string }>
   clawhubInstall: (slug: string) => Promise<CliResult>


### PR DESCRIPTION
变更说明

本 PR 主要完成了三部分工作。

第一，新增 Agent 管理能力（前后端联动）
 新增 Agent 管理页面，并接入应用路由与侧边栏入口。
 增加 Agent 的创建、编辑、删除与配置维护相关交互。
 补齐渲染层到主进程的能力链路：Preload API、IPC Handler 与类型定义同步更新。

第二，飞书渠道多 Bot 配置简化
 渠道页改为飞书单入口展示，降低配置复杂度与认知负担。
 统一飞书插件启停与状态展示逻辑，减少多处状态分叉。
 清理 legacy 插件标识与兼容分支，收敛到新的插件标识与配置路径。

第三，版本与开发体验改进
 同步 2026.3.31 版本策略。
 修复开发态 Electron 在 dev server 短暂不可用时的加载失败问题，增加重试机制，降低本地启动偶发白屏概率。

## 变更类型

- [ ] Bug 修复
- [ ✅] 新功能
- [✅ ] 重构 / 优化
- [ ] 依赖更新
- [ ] CI / 构建配置
- [ ] 文档

## 影响范围

- [ ✅ ] Electron 主进程 (`electron/main/`)
- [ ✅ ] Preload / IPC 桥接 (`electron/preload/`)
- [ ✅ ] React 渲染层 (`src/`)
- [ ] 构建与打包配置
- [ ] 文档

## 测试

- [ ✅ ] 已通过 `npm run typecheck`
- [ ✅ ] 已通过 `npm test`
- [ ✅ ] 已在本地运行 `npm run dev` 验证功能

## 截图 / 录屏

<img width="1381" height="837" alt="image" src="https://github.com/user-attachments/assets/6d48a666-d2a3-4e9a-9eeb-9857c6813052" />
<img width="1381" height="837" alt="image" src="https://github.com/user-attachments/assets/3a553fae-fe5a-442b-a506-c571a000a7d5" />


