### PR TITLE
feat: ClawHub skill 搜索切换到 CN 镜像

### DIFF
--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -999,7 +999,7 @@ export function registerIpcHandlers() {
     const locations = await getOpenClawSkillLocations()
     const result = await runShell(
       'npx',
-      ['-y', 'clawhub', 'search', query, '--limit', String(limit)],
+      ['-y', 'clawhub', 'search', query, '--limit', String(limit), '--registry', 'https://mirror-cn.clawhub.com'],
       undefined,
       { cwd: locations.clawhubWorkdir, controlDomain: 'plugin-install' }
     )


### PR DESCRIPTION
## Summary
- ClawHub skill 搜索请求切换到 CN 镜像 (`https://mirror-cn.clawhub.com`)，通过 `--registry` 参数覆盖默认 registry
- 仅影响搜索，安装等其他操作不变

## Test plan
- [X] 验证 Skills 页面 ClawHub 搜索功能正常（走镜像）
- [X] 验证安装、更新等其他 skill 操作不受影响