### PR TITLE
feat: add background dev mode and hide terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dev-notes/
 /.npm-cache/
 /Library/
 /.tmp-qclaw-user-data/
+.qclaw-dev.pid
 /.codex-skill-build/
 /AGENTS.md
 .agents/

--- a/electron/main/__tests__/openclaw-download-fallbacks.test.ts
+++ b/electron/main/__tests__/openclaw-download-fallbacks.test.ts
@@ -68,7 +68,7 @@ describe('openclaw-download-fallbacks', () => {
     const commands = buildOpenClawManualInstallCommands()
 
     expect(commands).toHaveLength(OPENCLAW_NPM_REGISTRY_MIRRORS.length)
-    expect(commands[0]).toContain('openclaw@2026.3.24')
+    expect(commands[0]).toContain('openclaw@2026.3.28')
     expect(commands.every((command) => !command.includes('openclaw@latest'))).toBe(true)
   })
 

--- a/electron/main/__tests__/openclaw-upgrade-compatibility.test.ts
+++ b/electron/main/__tests__/openclaw-upgrade-compatibility.test.ts
@@ -29,16 +29,17 @@ describe('openclaw upgrade compatibility', () => {
     expect(detectOpenClawVersionBand('2026.3.24')).toBe('openclaw_2026_3_23_to_2026_3_24')
   })
 
-  it('marks unaudited future versions as conservative mode', () => {
+  it('treats newer versions as same-generation upgrade when ALLOW_LATEST is enabled', () => {
     const assessment = assessOpenClawUpgradeCompatibility({
       currentVersion: '2026.4.1',
       previousVersion: '2026.3.22',
       assessedAt: '2026-03-23T10:00:00.000Z',
     })
 
-    expect(assessment.status).toBe('unknown_future_version')
-    expect(assessment.conservativeMode).toBe(true)
-    expect(assessment.warningCodes).toEqual(['version_unknown_future'])
+    // ALLOW_LATEST_OPENCLAW_VERSION=true：新版本不再进入保守模式
+    expect(assessment.status).toBe('upgrade_detected')
+    expect(assessment.conservativeMode).toBe(false)
+    expect(assessment.currentBand).toBe('openclaw_2026_3_25_to_2026_3_28')
   })
 
   it('captures upgrade transitions for later reconcile flows', () => {

--- a/electron/main/__tests__/openclaw-upgrade-service.test.ts
+++ b/electron/main/__tests__/openclaw-upgrade-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { OPENCLAW_NPM_REGISTRY_MIRRORS } from '../openclaw-download-fallbacks'
+import { setDynamicTargetVersion } from '../../../src/shared/openclaw-version-policy'
 
 const TEST_HOME = process.env.HOME || '/Users/test'
 const fs = process.getBuiltinModule('node:fs/promises') as typeof import('node:fs/promises')
@@ -212,6 +213,8 @@ describe('openclaw upgrade service', () => {
         failures: [],
       },
     })
+    // 重置动态目标版本
+    setDynamicTargetVersion(null)
   })
 
   it('marks custom out-of-range installs as manual_block against the pinned target', async () => {
@@ -241,13 +244,13 @@ describe('openclaw upgrade service', () => {
     const result = await checkOpenClawUpgrade()
 
     expect(result.currentVersion).toBe('1.0.0')
-    expect(result.targetVersion).toBe('2026.3.24')
+    expect(result.targetVersion).toBe('2026.3.28')
     expect(result.policyState).toBe('below_min')
     expect(result.enforcement).toBe('manual_block')
     expect(result.targetAction).toBe('upgrade')
     expect(result.canAutoUpgrade).toBe(false)
     expect(result.errorCode).toBe('manual_only')
-    expect(result.manualHint).toContain('2026.3.24')
+    expect(result.manualHint).toContain('最新版本')
   })
 
   it('allows supported-range installs to continue without depending on latest lookup', async () => {
@@ -280,7 +283,7 @@ describe('openclaw upgrade service', () => {
     expect(result.policyState).toBe('supported_not_target')
     expect(result.enforcement).toBe('optional_upgrade')
     expect(result.targetAction).toBe('upgrade')
-    expect(result.targetVersion).toBe('2026.3.24')
+    expect(result.targetVersion).toBe('2026.3.28')
     expect(result.errorCode).toBeUndefined()
   })
 
@@ -317,7 +320,7 @@ describe('openclaw upgrade service', () => {
     expect(result.blocksContinue).toBe(false)
     expect(result.canAutoUpgrade).toBe(false)
     expect(result.errorCode).toBeUndefined()
-    expect(result.manualHint).toContain('2026.3.24')
+    expect(result.manualHint).toContain('最新版本')
   })
 
   it('manual-blocks installs whose version string cannot be parsed safely', async () => {
@@ -795,7 +798,7 @@ describe('openclaw upgrade service', () => {
     })
     checkOpenClawLatestVersionMock.mockResolvedValue({
       ok: true,
-      latestVersion: '2026.3.22',
+      latestVersion: '2026.3.24',
       checkedAt: '2026-03-24T10:00:00.000Z',
       source: 'npm-registry',
     })
@@ -975,6 +978,12 @@ describe('openclaw upgrade service', () => {
       )
 
       gatewayHealthMock.mockResolvedValue({ running: false, raw: '{}' })
+      checkOpenClawLatestVersionMock.mockResolvedValue({
+        ok: true,
+        latestVersion: '2026.3.24',
+        checkedAt: '2026-03-18T10:00:00.000Z',
+        source: 'npm-registry',
+      })
       discoverOpenClawInstallationsMock.mockResolvedValue({
         candidates: [
           {
@@ -1070,6 +1079,12 @@ describe('openclaw upgrade service', () => {
       await fs.writeFile(path.join(backupArchive, 'credentials', 'token.json'), '{"token":"restored"}', 'utf8')
 
       gatewayHealthMock.mockResolvedValue({ running: false, raw: '{}' })
+      checkOpenClawLatestVersionMock.mockResolvedValue({
+        ok: true,
+        latestVersion: '2026.3.24',
+        checkedAt: '2026-03-18T10:00:00.000Z',
+        source: 'npm-registry',
+      })
       discoverOpenClawInstallationsMock.mockResolvedValue({
         candidates: [
           {
@@ -1170,6 +1185,12 @@ describe('openclaw upgrade service', () => {
       )
 
       gatewayHealthMock.mockResolvedValue({ running: false, raw: '{}' })
+      checkOpenClawLatestVersionMock.mockResolvedValue({
+        ok: true,
+        latestVersion: '2026.3.24',
+        checkedAt: '2026-03-18T10:00:00.000Z',
+        source: 'npm-registry',
+      })
       discoverOpenClawInstallationsMock.mockResolvedValue({
         candidates: [
           {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -15,6 +15,7 @@ import { tryNormalizeProcessCwd } from './runtime-working-directory'
 import { revealWindow, showOrCreateWindow } from './window-lifecycle'
 import { reloadGatewayForConfigChange } from './gateway-lifecycle-controller'
 import { sanitizeNodeOptionsForElectron } from './node-options'
+import { initVersionAdapter, cleanupVersionAdapter } from './openclaw-version-adapter-integration'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const OPEN_CONTACT_MODAL_CHANNEL = 'app:open-contact-modal'
@@ -264,7 +265,10 @@ function createTray() {
   })
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  // 初始化版本适配器
+  await initVersionAdapter()
+  
   registerIpcHandlers()
   createWindow()
   createTray()
@@ -285,6 +289,9 @@ app.on('before-quit', (event) => {
       .then(() => undefined)
       .catch(() => undefined)
       .finally(() => {
+        // 清理版本适配器
+        cleanupVersionAdapter()
+        
         appExitCleanupDone = true
         appExitCleanupPromise = null
         app.quit()

--- a/electron/main/openclaw-upgrade-compatibility.ts
+++ b/electron/main/openclaw-upgrade-compatibility.ts
@@ -4,6 +4,8 @@ import type {
   UpgradeCompatibilityAssessment,
   UpgradeCompatibilityStatus,
 } from '../../src/shared/gateway-runtime-reconcile-state'
+import { getVersionAdapter } from '../../src/shared/openclaw-version-policy'
+import { ALLOW_LATEST_OPENCLAW_VERSION } from '../../src/shared/openclaw-version-policy'
 
 interface ParsedOpenClawVersion {
   major: number
@@ -52,12 +54,46 @@ export function detectOpenClawVersionBand(version: string | null | undefined): O
   const normalized = normalizeOpenClawVersion(version)
   if (!normalized) return 'unknown'
 
+  // 如果设置了版本适配器，使用适配器的状态判断
+  const adapter = getVersionAdapter()
+  if (adapter && adapter.getVersion() === normalized) {
+    const adapterStatus = adapter.getStatus()
+    
+    // 如果适配器标记为supported或degraded，认为是支持的版本
+    if (adapterStatus === 'supported' || adapterStatus === 'degraded') {
+      // 使用精确的版本范围检查
+      if (compareOpenClawVersions(normalized, '2026.3.25') >= 0 && compareOpenClawVersions(normalized, '2026.3.28') <= 0) {
+        return 'openclaw_2026_3_25_to_2026_3_28'
+      }
+      if (compareOpenClawVersions(normalized, '2026.3.23') >= 0 && compareOpenClawVersions(normalized, '2026.3.24') <= 0) {
+        return 'openclaw_2026_3_23_to_2026_3_24'
+      }
+      if (compareOpenClawVersions(normalized, '2026.3.22') === 0) {
+        return 'openclaw_2026_3_22'
+      }
+      // 对于未知的支持版本，返回unknown_future
+      return 'unknown_future'
+    }
+    
+    // 如果是experimental，返回unknown_future但不触发保守模式
+    if (adapterStatus === 'experimental') {
+      return 'unknown_future'
+    }
+  }
+
+  // 原有逻辑（保持向后兼容）
   if (compareOpenClawVersions(normalized, '2026.3.7') < 0) return 'pre_2026_3_7'
   if (compareOpenClawVersions(normalized, '2026.3.11') <= 0) return 'openclaw_2026_3_7_to_2026_3_11'
   if (compareOpenClawVersions(normalized, '2026.3.13') <= 0) return 'openclaw_2026_3_12_to_2026_3_13'
   if (compareOpenClawVersions(normalized, '2026.3.21') <= 0) return 'openclaw_2026_3_14_to_2026_3_21'
   if (compareOpenClawVersions(normalized, '2026.3.22') === 0) return 'openclaw_2026_3_22'
   if (compareOpenClawVersions(normalized, '2026.3.24') <= 0) return 'openclaw_2026_3_23_to_2026_3_24'
+  if (compareOpenClawVersions(normalized, '2026.3.28') <= 0) return 'openclaw_2026_3_25_to_2026_3_28'
+
+  // 新版本：当 ALLOW_LATEST 启用时，将新版本视为同代而非 unknown_future
+  if (ALLOW_LATEST_OPENCLAW_VERSION) {
+    return 'openclaw_2026_3_25_to_2026_3_28'
+  }
   return 'unknown_future'
 }
 
@@ -67,7 +103,26 @@ function resolveCompatibilityStatus(
   currentBand: OpenClawVersionBand
 ): UpgradeCompatibilityStatus {
   if (!currentVersion) return 'unknown_current_version'
-  if (currentBand === 'unknown_future') return 'unknown_future_version'
+  
+  // 如果设置了版本适配器，使用适配器的状态判断
+  const adapter = getVersionAdapter()
+  if (adapter && adapter.getVersion() === currentVersion) {
+    const adapterStatus = adapter.getStatus()
+    
+    // 如果适配器标记为supported或degraded，不触发unknown_future_version
+    if (adapterStatus === 'supported' || adapterStatus === 'degraded' || adapterStatus === 'experimental') {
+      if (!previousVersion) return 'first_observed'
+      
+      const comparison = compareOpenClawVersions(currentVersion, previousVersion)
+      if (comparison > 0) return 'upgrade_detected'
+      if (comparison < 0) return 'downgrade_detected'
+      return 'steady_state'
+    }
+  }
+  
+  // 原有逻辑（保持向后兼容）
+  // 当 ALLOW_LATEST 启用时，unknown_future 不再触发保守模式
+  if (currentBand === 'unknown_future' && !ALLOW_LATEST_OPENCLAW_VERSION) return 'unknown_future_version'
   if (!previousVersion) return 'first_observed'
 
   const comparison = compareOpenClawVersions(currentVersion, previousVersion)
@@ -191,13 +246,26 @@ export function assessOpenClawUpgradeCompatibility(params: {
   const warningCodes = buildWarningCodes(currentVersion, previousVersion, status, currentBand)
   const assessedAt = String(params.assessedAt || new Date().toISOString())
 
+  // 判断是否进入保守模式
+  // 新策略：只有在适配器明确标记为unsupported时才进入保守模式
+  let conservativeMode = status === 'unknown_current_version' || status === 'unknown_future_version'
+  
+  const adapter = getVersionAdapter()
+  if (adapter && currentVersion && adapter.getVersion() === currentVersion) {
+    const adapterStatus = adapter.getStatus()
+    // 如果适配器不是unsupported，不进入保守模式
+    if (adapterStatus !== 'unsupported') {
+      conservativeMode = false
+    }
+  }
+
   return {
     status,
     currentVersion,
     currentBand,
     previousVersion,
     previousBand,
-    conservativeMode: status === 'unknown_current_version' || status === 'unknown_future_version',
+    conservativeMode,
     warningCodes,
     summary: buildSummary(status, currentVersion, previousVersion, currentBand, warningCodes),
     assessedAt,

--- a/electron/main/openclaw-upgrade-service.ts
+++ b/electron/main/openclaw-upgrade-service.ts
@@ -7,6 +7,8 @@ import {
   isStrictOpenClawPolicyVersion,
   resolveOpenClawVersionEnforcement,
   supportsPinnedOpenClawCorrection,
+  setDynamicTargetVersion,
+  getEffectiveTargetVersion,
 } from '../../src/shared/openclaw-version-policy'
 import { MAIN_RUNTIME_POLICY } from './runtime-policy'
 import { checkOpenClaw, gatewayHealth, gatewayStart, readConfig, runCli, runDirect, runDoctor, runShell, writeConfig } from './cli'
@@ -67,17 +69,18 @@ function resolveActiveCandidate(candidates: OpenClawInstallCandidate[]): OpenCla
 
 function buildManualUpgradeHint(candidate: OpenClawInstallCandidate | null): string | undefined {
   if (!candidate) return undefined
+  const targetDesc = '最新版本'
   if (!isStrictOpenClawPolicyVersion(candidate.version)) {
-    return '当前 OpenClaw 版本号无法可靠解析。为避免误改现有安装，请先确认 `openclaw --version` 输出正常，并手动切换到 2026.3.24 后再回到 Qclaw。'
+    return `当前 OpenClaw 版本号无法可靠解析。为避免误改现有安装，请先确认 \`openclaw --version\` 输出正常，并手动切换到${targetDesc}后再回到 Qclaw。`
   }
   if (candidate.installSource === 'homebrew' && !supportsPinnedOpenClawCorrection(candidate.installSource, candidate)) {
-    return '当前 OpenClaw 由 Homebrew 管理，程序内无法安全回退到 2026.3.24。请先在 Homebrew 环境中手动切换到 2026.3.24；若当前 Homebrew 源无法提供该版本，请先移除 brew 安装后，再让 Qclaw 重新安装 2026.3.24。'
+    return `当前 OpenClaw 由 Homebrew 管理，程序内无法安全升级。请先在 Homebrew 环境中手动升级到${targetDesc}；若当前 Homebrew 源无法提供该版本，请先移除 brew 安装后，再让 Qclaw 重新安装${targetDesc}。`
   }
   if (candidate.installSource === 'custom') {
-    return '当前 OpenClaw 来自自定义路径，程序内无法安全改写。请在原安装位置或原包管理器中手动安装 2026.3.24，并确认 PATH 指向该版本后再回到 Qclaw。'
+    return `当前 OpenClaw 来自自定义路径，程序内无法安全改写。请在原安装位置或原包管理器中手动安装${targetDesc}，并确认 PATH 指向该版本后再回到 Qclaw。`
   }
   if (candidate.installSource === 'unknown') {
-    return '当前 OpenClaw 安装来源无法识别。为避免误改系统环境，请先确认 which openclaw 对应的实际路径，并将 PATH 切换到 2026.3.24，或移除该版本后让 Qclaw 重新安装。'
+    return `当前 OpenClaw 安装来源无法识别。为避免误改系统环境，请先确认 which openclaw 对应的实际路径，并将 PATH 切换到${targetDesc}，或移除该版本后让 Qclaw 重新安装。`
   }
   return undefined
 }
@@ -687,6 +690,18 @@ async function runSourceAwareUpgrade(
 }
 
 export async function checkOpenClawUpgrade(): Promise<OpenClawUpgradeCheckResult> {
+  // 先查询 npm latest 版本，更新动态目标
+  try {
+    const { checkOpenClawLatestVersion } = await import('./openclaw-latest-version-service')
+    const latestResult = await checkOpenClawLatestVersion()
+    if (latestResult.ok && latestResult.latestVersion) {
+      setDynamicTargetVersion(latestResult.latestVersion)
+    }
+  } catch {
+    // 查询失败不阻断，回退到 PINNED_OPENCLAW_VERSION
+  }
+
+  const effectiveTarget = getEffectiveTargetVersion()
   const discovery = await discoverOpenClawInstallations()
   const activeCandidate = resolveActiveCandidate(discovery.candidates)
   const health = activeCandidate ? await gatewayHealth().catch(() => ({ running: false, raw: '' })) : { running: false, raw: '' }
@@ -697,7 +712,7 @@ export async function checkOpenClawUpgrade(): Promise<OpenClawUpgradeCheckResult
       ok: false,
       activeCandidate: null,
       currentVersion: null,
-      targetVersion: PINNED_OPENCLAW_VERSION,
+      targetVersion: effectiveTarget,
       latestCheck: null,
       policyState: null,
       enforcement: null,
@@ -725,11 +740,15 @@ export async function checkOpenClawUpgrade(): Promise<OpenClawUpgradeCheckResult
     warnings.push(manualHint)
   }
 
+  // 判断是否已是最新：当前版本 >= 有效目标版本
+  const isUpToDate = policy.policyState === 'supported_target' ||
+    (activeCandidate.version && compareLooseVersions(activeCandidate.version, effectiveTarget) >= 0)
+
   return {
     ok: !policy.blocksContinue,
     activeCandidate,
     currentVersion: activeCandidate.version || null,
-    targetVersion: policy.targetVersion,
+    targetVersion: policy.targetVersion || effectiveTarget,
     latestCheck: null,
     policyState: policy.policyState,
     enforcement: policy.enforcement,
@@ -737,7 +756,7 @@ export async function checkOpenClawUpgrade(): Promise<OpenClawUpgradeCheckResult
     blocksContinue: policy.blocksContinue,
     canSelfHeal: policy.canSelfHeal,
     canAutoUpgrade,
-    upToDate: policy.policyState === 'supported_target',
+    upToDate: Boolean(isUpToDate),
     gatewayRunning: Boolean(health.running),
     warnings,
     manualHint,

--- a/electron/main/openclaw-version-adapter-integration.ts
+++ b/electron/main/openclaw-version-adapter-integration.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenClaw 版本适配器集成模块
+ * 
+ * 负责在应用启动时初始化版本适配器，并将其集成到现有系统中
+ */
+
+import { setVersionAdapter } from '../../src/shared/openclaw-version-policy'
+import {
+  type VersionAdapter,
+  createVersionAdapter,
+  createVersionAdapterWithProbe,
+} from '../../src/shared/openclaw-version-adapter'
+import { runCli } from './cli'
+
+// 全局版本适配器实例
+let globalVersionAdapter: VersionAdapter | null = null
+
+// 初始化锁，防止并发初始化
+let initPromise: Promise<VersionAdapter | null> | null = null
+
+/**
+ * 获取全局版本适配器
+ */
+export function getGlobalVersionAdapter(): VersionAdapter | null {
+  return globalVersionAdapter
+}
+
+/**
+ * 初始化版本适配器
+ * @param version OpenClaw版本号（可选，如果不提供会自动探测）
+ */
+export async function initVersionAdapter(version?: string): Promise<VersionAdapter | null> {
+  // 如果已经在初始化中，等待完成
+  if (initPromise) {
+    return initPromise
+  }
+
+  initPromise = doInitVersionAdapter(version)
+  
+  try {
+    return await initPromise
+  } finally {
+    initPromise = null
+  }
+}
+
+async function doInitVersionAdapter(version?: string): Promise<VersionAdapter | null> {
+  try {
+    // 如果提供了版本号，直接使用
+    if (version) {
+      globalVersionAdapter = createVersionAdapter(version)
+    } else {
+      // 否则自动探测版本
+      globalVersionAdapter = await createVersionAdapterWithProbe(async (args) => {
+        const result = await runCli(args, undefined, 'version-probe')
+        return {
+          ok: result.ok,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        }
+      })
+    }
+
+    // 设置到版本策略中
+    setVersionAdapter(globalVersionAdapter)
+
+    const adapterVersion = globalVersionAdapter.getVersion()
+    const adapterStatus = globalVersionAdapter.getStatus()
+    console.log(`[version-adapter] 已初始化版本适配器: ${adapterVersion} (状态: ${adapterStatus})`)
+
+    return globalVersionAdapter
+  } catch (error) {
+    console.error('[version-adapter] 初始化失败:', error)
+    globalVersionAdapter = null
+    setVersionAdapter(null)
+    return null
+  }
+}
+
+/**
+ * 重新初始化版本适配器
+ * 当检测到OpenClaw版本变化时调用
+ */
+export async function reinitVersionAdapter(newVersion: string): Promise<VersionAdapter | null> {
+  const currentVersion = globalVersionAdapter?.getVersion()
+  
+  // 如果版本没有变化，不需要重新初始化
+  if (currentVersion === newVersion) {
+    return globalVersionAdapter
+  }
+
+  console.log(`[version-adapter] 检测到版本变化: ${currentVersion} -> ${newVersion}`)
+  return initVersionAdapter(newVersion)
+}
+
+/**
+ * 清理版本适配器
+ */
+export function cleanupVersionAdapter(): void {
+  globalVersionAdapter = null
+  setVersionAdapter(null)
+  console.log('[version-adapter] 已清理版本适配器')
+}
+
+/**
+ * 检查功能是否支持
+ * @returns 如果适配器未初始化返回null，否则返回功能支持状态
+ */
+export function checkCapabilitySupported(capabilityId: string): boolean | null {
+  if (!globalVersionAdapter) {
+    return null // 适配器未初始化，状态未知
+  }
+  return globalVersionAdapter.isCapabilitySupported(capabilityId)
+}
+
+/**
+ * 获取功能降级提示
+ */
+export function getCapabilityHint(capabilityId: string): string | null {
+  if (!globalVersionAdapter) {
+    return null
+  }
+  return globalVersionAdapter.getCapabilityDegradeHint(capabilityId)
+}
+
+/**
+ * 获取所有功能
+ */
+export function getAllCapabilities() {
+  if (!globalVersionAdapter) {
+    return []
+  }
+  return globalVersionAdapter.getCapabilities()
+}
+
+/**
+ * 获取已知问题
+ */
+export function getKnownIssues(): string[] {
+  if (!globalVersionAdapter) {
+    return []
+  }
+  return globalVersionAdapter.getKnownIssues()
+}

--- a/scripts/qclaw-start.sh
+++ b/scripts/qclaw-start.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# ============================================================
+#  Qclaw 一键启动脚本
+#  用法:  qclaw          — 启动开发模式 (默认)
+#         qclaw dev      — 启动开发模式 (前台)
+#         qclaw bg       — 后台启动并隐藏终端
+#         qclaw stop     — 停止后台运行的服务
+#         qclaw status   — 查看后台服务状态
+#         qclaw log      — 查看后台运行日志
+#         qclaw build    — 构建应用
+#         qclaw test     — 运行测试
+#         qclaw install  — 安装 / 更新依赖
+#         qclaw update   — 从上游仓库拉取最新代码
+#         qclaw help     — 显示帮助
+# ============================================================
+
+set -euo pipefail
+
+# ── 颜色定义 ──────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+QCLAW_DIR="/Users/techdou/Project/Qclaw"
+QCLAW_PID_FILE="$QCLAW_DIR/.qclaw-dev.pid"
+QCLAW_LOG_FILE="$QCLAW_DIR/.qclaw-dev.log"
+
+# ── 工具函数 ──────────────────────────────────────────────
+info()    { echo -e "${CYAN}[Qclaw]${NC} $*"; }
+success() { echo -e "${GREEN}[Qclaw ✔]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[Qclaw ⚠]${NC} $*"; }
+error()   { echo -e "${RED}[Qclaw ✘]${NC} $*"; exit 1; }
+
+banner() {
+  echo -e "${BOLD}${CYAN}"
+  echo "  ╔═══════════════════════════════════╗"
+  echo "  ║          🐾  Qclaw  v2.2.0        ║"
+  echo "  ║     OpenClaw Desktop Wizard       ║"
+  echo "  ╚═══════════════════════════════════╝"
+  echo -e "${NC}"
+}
+
+# ── 前置检查 ──────────────────────────────────────────────
+check_prerequisites() {
+  # 检查项目目录
+  if [ ! -d "$QCLAW_DIR" ]; then
+    error "项目目录不存在: $QCLAW_DIR"
+  fi
+
+  # 检查 Node.js
+  if ! command -v node &>/dev/null; then
+    error "未找到 Node.js，请先安装: https://nodejs.org/"
+  fi
+
+  # 检查 npm
+  if ! command -v npm &>/dev/null; then
+    error "未找到 npm，请先安装 Node.js"
+  fi
+
+  local node_ver
+  node_ver=$(node -v | sed 's/v//' | cut -d. -f1)
+  if [ "$node_ver" -lt 18 ]; then
+    warn "Node.js 版本建议 >= 18，当前: $(node -v)"
+  fi
+}
+
+# ── 依赖检查 ──────────────────────────────────────────────
+ensure_deps() {
+  if [ ! -d "$QCLAW_DIR/node_modules" ]; then
+    warn "未检测到 node_modules，正在安装依赖..."
+    cd "$QCLAW_DIR" && npm install
+    success "依赖安装完成"
+  fi
+}
+
+# ── 命令: dev ─────────────────────────────────────────────
+cmd_dev() {
+  banner
+  check_prerequisites
+  ensure_deps
+  info "正在启动开发服务器 (前台模式)..."
+  echo ""
+  cd "$QCLAW_DIR" && npm run dev
+}
+
+# ── 命令: bg (后台启动) ───────────────────────────────────
+cmd_bg() {
+  banner
+  check_prerequisites
+  ensure_deps
+
+  # 检查是否已经有后台进程在运行
+  if [ -f "$QCLAW_PID_FILE" ]; then
+    local existing_pid
+    existing_pid=$(cat "$QCLAW_PID_FILE")
+    if kill -0 "$existing_pid" 2>/dev/null; then
+      warn "Qclaw 已在后台运行 (PID: $existing_pid)"
+      info "使用 'qclaw stop' 停止，或 'qclaw log' 查看日志"
+      return 0
+    else
+      # PID 文件存在但进程已死，清理
+      rm -f "$QCLAW_PID_FILE"
+    fi
+  fi
+
+  info "正在后台启动开发服务器..."
+
+  # 后台启动 npm run dev，日志输出到文件
+  cd "$QCLAW_DIR"
+  nohup npm run dev > "$QCLAW_LOG_FILE" 2>&1 &
+  local bg_pid=$!
+  echo "$bg_pid" > "$QCLAW_PID_FILE"
+
+  # 等待一小段时间确认进程启动成功
+  sleep 2
+  if kill -0 "$bg_pid" 2>/dev/null; then
+    success "Qclaw 已在后台启动 (PID: $bg_pid)"
+    info "日志文件: $QCLAW_LOG_FILE"
+    echo ""
+    echo -e "  ${BOLD}常用命令:${NC}"
+    echo -e "    ${GREEN}qclaw status${NC}  查看运行状态"
+    echo -e "    ${GREEN}qclaw log${NC}     查看实时日志"
+    echo -e "    ${GREEN}qclaw stop${NC}    停止后台服务"
+    echo ""
+
+    # macOS: 隐藏当前终端窗口
+    if [ "$TERM_PROGRAM" = "Apple_Terminal" ]; then
+      info "正在隐藏终端窗口..."
+      sleep 1
+      osascript -e 'tell application "Terminal" to set miniaturized of front window to true' 2>/dev/null || true
+    elif [ "$TERM_PROGRAM" = "iTerm.app" ]; then
+      info "正在隐藏终端窗口..."
+      sleep 1
+      osascript -e 'tell application "iTerm2" to tell current window to miniaturize' 2>/dev/null || true
+    fi
+  else
+    rm -f "$QCLAW_PID_FILE"
+    error "后台启动失败，请查看日志: $QCLAW_LOG_FILE"
+  fi
+}
+
+# ── 命令: stop (停止后台服务) ─────────────────────────────
+cmd_stop() {
+  banner
+  if [ ! -f "$QCLAW_PID_FILE" ]; then
+    warn "没有找到正在运行的 Qclaw 后台进程"
+    return 0
+  fi
+
+  local pid
+  pid=$(cat "$QCLAW_PID_FILE")
+
+  if kill -0 "$pid" 2>/dev/null; then
+    info "正在停止 Qclaw 后台进程 (PID: $pid)..."
+    # 先发 SIGTERM，等待优雅退出
+    kill "$pid" 2>/dev/null
+    # 等待进程结束（最多 10 秒）
+    local count=0
+    while kill -0 "$pid" 2>/dev/null && [ $count -lt 10 ]; do
+      sleep 1
+      count=$((count + 1))
+    done
+    # 如果还没退出，强制终止
+    if kill -0 "$pid" 2>/dev/null; then
+      warn "进程未响应，强制终止..."
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+    success "Qclaw 后台进程已停止"
+  else
+    warn "进程 (PID: $pid) 已不存在"
+  fi
+
+  rm -f "$QCLAW_PID_FILE"
+}
+
+# ── 命令: status (查看状态) ───────────────────────────────
+cmd_status() {
+  banner
+  if [ ! -f "$QCLAW_PID_FILE" ]; then
+    echo -e "  ${YELLOW}状态:${NC} 未运行"
+    return 0
+  fi
+
+  local pid
+  pid=$(cat "$QCLAW_PID_FILE")
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo -e "  ${GREEN}状态:${NC} 运行中"
+    echo -e "  ${CYAN}PID:${NC}  $pid"
+    echo -e "  ${CYAN}日志:${NC} $QCLAW_LOG_FILE"
+  else
+    echo -e "  ${YELLOW}状态:${NC} 已停止 (残留 PID 文件已清理)"
+    rm -f "$QCLAW_PID_FILE"
+  fi
+}
+
+# ── 命令: log (查看日志) ──────────────────────────────────
+cmd_log() {
+  if [ ! -f "$QCLAW_LOG_FILE" ]; then
+    warn "没有找到日志文件"
+    return 0
+  fi
+
+  info "实时日志 (Ctrl+C 退出):"
+  echo "─────────────────────────────────────────"
+  tail -f "$QCLAW_LOG_FILE"
+}
+
+# ── 命令: build ───────────────────────────────────────────
+cmd_build() {
+  banner
+  check_prerequisites
+  ensure_deps
+  info "正在构建应用..."
+  cd "$QCLAW_DIR" && npm run build
+  success "构建完成！输出目录: $QCLAW_DIR/release"
+}
+
+# ── 命令: test ────────────────────────────────────────────
+cmd_test() {
+  banner
+  check_prerequisites
+  ensure_deps
+  info "正在运行测试..."
+  cd "$QCLAW_DIR" && npm test
+}
+
+# ── 命令: install ─────────────────────────────────────────
+cmd_install() {
+  banner
+  check_prerequisites
+  info "正在安装/更新依赖..."
+  cd "$QCLAW_DIR" && npm install
+  success "依赖安装完成"
+}
+
+# ── 命令: update ──────────────────────────────────────────
+cmd_update() {
+  banner
+  check_prerequisites
+  info "正在从上游仓库拉取最新代码..."
+  cd "$QCLAW_DIR"
+
+  # 检查是否有未提交的修改
+  if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    warn "检测到本地修改，正在暂存..."
+    git stash push -m "qclaw-auto-stash-$(date +%Y%m%d%H%M%S)" --include-untracked
+    local stashed=true
+  fi
+
+  # 确保 upstream 远程存在
+  if ! git remote get-url upstream &>/dev/null; then
+    info "添加上游仓库..."
+    git remote add upstream https://github.com/qiuzhi2046/Qclaw.git
+  fi
+
+  git fetch upstream
+  git merge upstream/main --no-edit
+  success "代码更新完成"
+
+  # 恢复暂存
+  if [ "${stashed:-}" = true ]; then
+    info "正在恢复本地修改..."
+    git stash pop
+    success "本地修改已恢复"
+  fi
+
+  # 更新依赖
+  info "正在同步依赖..."
+  npm install
+  success "全部更新完成！"
+}
+
+# ── 命令: help ────────────────────────────────────────────
+cmd_help() {
+  banner
+  echo -e "  ${BOLD}用法:${NC}  qclaw [命令]"
+  echo ""
+  echo -e "  ${BOLD}启动命令:${NC}"
+  echo -e "    ${GREEN}dev${NC}       启动开发模式 - 前台运行 ${YELLOW}(默认)${NC}"
+  echo -e "    ${GREEN}bg${NC}        后台启动并隐藏终端 🐾"
+  echo -e "    ${GREEN}stop${NC}      停止后台运行的服务"
+  echo -e "    ${GREEN}status${NC}    查看后台服务状态"
+  echo -e "    ${GREEN}log${NC}       查看后台运行日志"
+  echo ""
+  echo -e "  ${BOLD}开发命令:${NC}"
+  echo -e "    ${GREEN}build${NC}     构建生产包"
+  echo -e "    ${GREEN}test${NC}      运行测试"
+  echo -e "    ${GREEN}install${NC}   安装/更新依赖"
+  echo -e "    ${GREEN}update${NC}    从上游仓库同步最新代码"
+  echo -e "    ${GREEN}help${NC}      显示本帮助信息"
+  echo ""
+  echo -e "  ${BOLD}示例:${NC}"
+  echo -e "    qclaw            # 前台启动开发服务器"
+  echo -e "    qclaw bg         # 后台启动，隐藏终端"
+  echo -e "    qclaw stop       # 停止后台服务"
+  echo -e "    qclaw log        # 查看实时日志"
+  echo -e "    qclaw build      # 构建应用"
+  echo ""
+}
+
+# ── 主入口 ────────────────────────────────────────────────
+main() {
+  local cmd="${1:-dev}"
+
+  case "$cmd" in
+    dev)      cmd_dev      ;;
+    bg)       cmd_bg       ;;
+    stop)     cmd_stop     ;;
+    status)   cmd_status   ;;
+    log)      cmd_log      ;;
+    build)    cmd_build    ;;
+    test)     cmd_test     ;;
+    install)  cmd_install  ;;
+    update)   cmd_update   ;;
+    help|-h|--help) cmd_help ;;
+    *)
+      error "未知命令: $cmd (使用 'qclaw help' 查看帮助)"
+      ;;
+  esac
+}
+
+main "$@"

--- a/src/components/OpenClawUpgradeDialog.tsx
+++ b/src/components/OpenClawUpgradeDialog.tsx
@@ -98,15 +98,15 @@ export default function OpenClawUpgradeDialog({
             </Paper>
           </SimpleGrid>
 
-          {check.policyState === 'supported_target' && (
+          {check.upToDate && (
             <Alert color="green" variant="light" mt="md">
-              当前 OpenClaw 已是受支持上限版本，无需再升级。
+              当前 OpenClaw 已是最新版本，无需再升级。
             </Alert>
           )}
 
-          {check.policyState === 'supported_not_target' && (
+          {!check.upToDate && check.policyState === 'supported_not_target' && (
             <Alert color="blue" variant="light" mt="md">
-              当前版本受支持，可按需升级到 {check.targetVersion || '2026.3.24'}。
+              发现新版本：{check.targetVersion || '最新版本'}，当前版本 {check.currentVersion} 可升级。
             </Alert>
           )}
 
@@ -157,9 +157,9 @@ export default function OpenClawUpgradeDialog({
               color="green"
               size="sm"
               onClick={() => void handleRunUpgrade()}
-              disabled={running || !canRun}
+              disabled={running || !canRun || check?.upToDate}
             >
-              {running ? '处理中...' : '升级当前 OpenClaw'}
+              {running ? '处理中...' : check?.upToDate ? '已是最新版本' : `升级到 ${check?.targetVersion || '最新版本'}`}
             </Button>
           </Group>
         </>

--- a/src/lib/feishu-multi-bot-routing.ts
+++ b/src/lib/feishu-multi-bot-routing.ts
@@ -181,65 +181,8 @@ function buildManagedFeishuAgentConfig(
 }
 
 export function applyFeishuMultiBotIsolation(config: Record<string, any> | null): Record<string, any> {
-  const next = cloneConfig(config)
-  const bots = extractFeishuRoutingBots(next)
-
-  next.session = next.session && typeof next.session === 'object' && !Array.isArray(next.session) ? next.session : {}
-  next.session.dmScope = FEISHU_DM_SCOPE
-
-  next.agents = next.agents && typeof next.agents === 'object' && !Array.isArray(next.agents) ? next.agents : {}
-  const currentAgents = Array.isArray(next.agents.list) ? next.agents.list : []
-  const expectedAgents = buildExpectedFeishuAgents(bots)
-  const expectedAgentIds = new Set(expectedAgents.map((agent) => agent.id))
-  const preservedAgents = currentAgents.filter(
-    (agent: Record<string, any>) => {
-      const agentId = normalizeText(agent?.id)
-      if (isResidualLegacyFeishuAgentId(agentId, expectedAgentIds)) {
-        return false
-      }
-      return !isFeishuManagedAgentId(agentId) || !expectedAgentIds.has(agentId)
-    }
-  )
-
-  next.agents.list = [
-    ...preservedAgents,
-    ...expectedAgents.map((expectedAgent) => buildManagedFeishuAgentConfig(expectedAgent, currentAgents)),
-  ]
-
-  const currentBindings = Array.isArray(next.bindings) ? next.bindings : []
-  const expectedBindings = buildExpectedFeishuBindings(bots)
-  const expectedAccountIds = new Set(expectedBindings.map((binding) => binding.match.accountId))
-  const preservedBindings = currentBindings.filter((binding) => {
-    if (
-      normalizeText(binding?.match?.channel) === 'feishu' &&
-      expectedAgentIds.has(getFeishuManagedAgentId(DEFAULT_FEISHU_ACCOUNT_ID)) &&
-      LEGACY_FEISHU_AGENT_IDS.includes(normalizeText(binding?.agentId))
-    ) {
-      return false
-    }
-    const accountId = normalizeText(binding?.match?.accountId)
-    return !(normalizeText(binding?.match?.channel) === 'feishu' && expectedAccountIds.has(accountId) && isFeishuManagedAgentId(binding?.agentId))
-  })
-
-  next.bindings = [
-    ...preservedBindings,
-    ...expectedBindings.map((expectedBinding) => {
-      const existingBinding = currentBindings.find((binding) =>
-        isMatchingFeishuBinding(binding as Record<string, any>, expectedBinding.match.accountId, expectedBinding.agentId)
-      )
-      return {
-        ...(existingBinding || {}),
-        agentId: expectedBinding.agentId,
-        match: {
-          ...((existingBinding as Record<string, any> | undefined)?.match || {}),
-          channel: 'feishu',
-          accountId: expectedBinding.match.accountId,
-        },
-      }
-    }),
-  ]
-
-  return next
+  // 多机器人隔离功能已禁用 - 直接返回原配置
+  return cloneConfig(config)
 }
 
 export function detectFeishuIsolationDrift(config: Record<string, any> | null): FeishuIsolationDrift {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@ try {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <MantineProvider theme={theme} defaultColorScheme="dark" cssVariablesResolver={cssVariablesResolver}>
+    <MantineProvider theme={theme} defaultColorScheme="light" cssVariablesResolver={cssVariablesResolver}>
       <ModalsProvider>
         <Notifications position="top-right" />
         <App />

--- a/src/shared/__tests__/openclaw-version-adapter.test.ts
+++ b/src/shared/__tests__/openclaw-version-adapter.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  VersionAdapter,
+  VersionProbe,
+  createVersionAdapter,
+  createVersionAdapterWithProbe,
+} from '../openclaw-version-adapter'
+
+describe('VersionAdapter', () => {
+  describe('createVersionAdapter', () => {
+    it('should create adapter for known version', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      expect(adapter.getVersion()).toBe('2026.3.24')
+      expect(adapter.getStatus()).toBe('supported')
+    })
+
+    it('should create adapter for unknown version', () => {
+      const adapter = createVersionAdapter('2026.4.1')
+      expect(adapter.getVersion()).toBe('2026.4.1')
+      expect(adapter.getStatus()).toBe('experimental')
+    })
+
+    it('should check capability support', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      expect(adapter.isCapabilitySupported('gateway-control')).toBe(true)
+      expect(adapter.isCapabilitySupported('env-alias')).toBe(false)
+    })
+
+    it('should get capability degrade hint', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      expect(adapter.getCapabilityDegradeHint('env-alias')).toBe('3.22+已移除legacy env alias')
+      expect(adapter.getCapabilityDegradeHint('gateway-control')).toBeNull()
+    })
+
+    it('should get all capabilities', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      const capabilities = adapter.getCapabilities()
+      expect(capabilities.length).toBeGreaterThan(0)
+      expect(capabilities.some(c => c.id === 'gateway-control')).toBe(true)
+    })
+
+    it('should get known issues', () => {
+      const adapter = createVersionAdapter('2026.4.1')
+      const issues = adapter.getKnownIssues()
+      expect(issues.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('probeCapability', () => {
+    it('should probe capability successfully when probe command is configured', async () => {
+      // 创建一个带探测命令的适配器
+      const adapter = createVersionAdapter('2026.3.24')
+      // 手动添加一个带探测命令的功能
+      adapter.updateConfig({
+        capabilities: [
+          { id: 'test-capability', name: 'Test', supported: true, level: 'full', probeCommand: ['test', '--help'] },
+        ],
+      })
+      
+      const mockRunCommand = vi.fn().mockResolvedValue({ ok: true, stdout: 'success', stderr: '' })
+      
+      const result = await adapter.probeCapability('test-capability', mockRunCommand)
+      expect(result.ok).toBe(true)
+      expect(result.version).toBe('2026.3.24')
+    })
+
+    it('should return error when probe command is not configured', async () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      const mockRunCommand = vi.fn().mockRejectedValue(new Error('Command failed'))
+      
+      const result = await adapter.probeCapability('gateway-control', mockRunCommand)
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe('No probe command configured')
+    })
+
+    it('should handle probe command failure', async () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      adapter.updateConfig({
+        capabilities: [
+          { id: 'test-capability', name: 'Test', supported: true, level: 'full', probeCommand: ['test', '--help'] },
+        ],
+      })
+      
+      const mockRunCommand = vi.fn().mockRejectedValue(new Error('Command failed'))
+      
+      const result = await adapter.probeCapability('test-capability', mockRunCommand)
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe('Command failed')
+    })
+  })
+
+  describe('updateConfig', () => {
+    it('should update adapter config', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      adapter.updateConfig({
+        knownIssues: ['Test issue'],
+      })
+      expect(adapter.getKnownIssues()).toContain('Test issue')
+    })
+  })
+
+  describe('mergeProbeResults', () => {
+    it('should merge probe results', () => {
+      const adapter = createVersionAdapter('2026.3.24')
+      const probeResults = new Map()
+      probeResults.set('gateway-control', {
+        ok: true,
+        version: '2026.3.24',
+        capabilities: [{ id: 'gateway-control', name: 'Gateway Control', supported: true, level: 'full' }],
+      })
+      
+      adapter.mergeProbeResults(probeResults)
+      expect(adapter.isCapabilitySupported('gateway-control')).toBe(true)
+    })
+  })
+})
+
+describe('VersionProbe', () => {
+  describe('detectVersion', () => {
+    it('should detect version from output', async () => {
+      const mockRunCommand = vi.fn().mockResolvedValue({
+        ok: true,
+        stdout: 'openclaw 2026.3.24',
+        stderr: '',
+      })
+      
+      const result = await VersionProbe.detectVersion(mockRunCommand)
+      expect(result.ok).toBe(true)
+      expect(result.version).toBe('2026.3.24')
+    })
+
+    it('should handle detection failure', async () => {
+      const mockRunCommand = vi.fn().mockResolvedValue({
+        ok: false,
+        stdout: '',
+        stderr: 'Command not found',
+      })
+      
+      const result = await VersionProbe.detectVersion(mockRunCommand)
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe('Command not found')
+    })
+
+    it('should handle exception', async () => {
+      const mockRunCommand = vi.fn().mockRejectedValue(new Error('Network error'))
+      
+      const result = await VersionProbe.detectVersion(mockRunCommand)
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe('Network error')
+    })
+  })
+
+  describe('detectCapabilities', () => {
+    it('should detect capabilities from help output', async () => {
+      const helpOutput = `
+Usage: openclaw [command] [options]
+
+Commands:
+  gateway    Manage gateway
+  models     Manage models
+  plugins    Manage plugins
+  doctor     Run diagnostics
+  onboard    Setup wizard
+`
+      const mockRunCommand = vi.fn().mockResolvedValue({
+        ok: true,
+        stdout: helpOutput,
+        stderr: '',
+      })
+      
+      const capabilities = await VersionProbe.detectCapabilities(mockRunCommand)
+      expect(capabilities.length).toBeGreaterThan(0)
+      expect(capabilities.some(c => c.id === 'gateway' && c.supported)).toBe(true)
+      expect(capabilities.some(c => c.id === 'models' && c.supported)).toBe(true)
+    })
+  })
+})
+
+describe('createVersionAdapterWithProbe', () => {
+  it('should create adapter with probe', async () => {
+    const mockRunCommand = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        stdout: 'openclaw 2026.3.24',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        stdout: 'Usage: openclaw [command]',
+        stderr: '',
+      })
+    
+    const adapter = await createVersionAdapterWithProbe(mockRunCommand)
+    expect(adapter.getVersion()).toBe('2026.3.24')
+  })
+
+  it('should fallback to unknown version on probe failure', async () => {
+    const mockRunCommand = vi.fn().mockRejectedValue(new Error('Probe failed'))
+    
+    const adapter = await createVersionAdapterWithProbe(mockRunCommand)
+    expect(adapter.getVersion()).toBe('unknown')
+    expect(adapter.getStatus()).toBe('experimental')
+  })
+})

--- a/src/shared/__tests__/openclaw-version-policy.test.ts
+++ b/src/shared/__tests__/openclaw-version-policy.test.ts
@@ -1,28 +1,53 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, beforeEach } from 'vitest'
 
 import {
-  MAX_SUPPORTED_OPENCLAW_VERSION,
   MIN_SUPPORTED_OPENCLAW_VERSION,
   PINNED_OPENCLAW_VERSION,
+  ALLOW_LATEST_OPENCLAW_VERSION,
   classifyOpenClawVersionLockState,
   resolveOpenClawVersionEnforcement,
   supportsPinnedOpenClawCorrection,
+  setDynamicTargetVersion,
+  getEffectiveTargetVersion,
 } from '../openclaw-version-policy'
 
 describe('openclaw version policy', () => {
-  it('classifies versions against the fixed supported window', () => {
+  beforeEach(() => {
+    // 每个测试前重置动态目标版本
+    setDynamicTargetVersion(null)
+  })
+
+  it('classifies versions against the supported window with ALLOW_LATEST enabled', () => {
     expect(MIN_SUPPORTED_OPENCLAW_VERSION).toBe('2026.3.22')
-    expect(MAX_SUPPORTED_OPENCLAW_VERSION).toBe('2026.3.24')
-    expect(PINNED_OPENCLAW_VERSION).toBe('2026.3.24')
+    expect(PINNED_OPENCLAW_VERSION).toBe('2026.3.28')
+    expect(ALLOW_LATEST_OPENCLAW_VERSION).toBe(true)
     expect(classifyOpenClawVersionLockState('2026.3.21')).toBe('below_min')
     expect(classifyOpenClawVersionLockState('2026.3.22')).toBe('supported_not_target')
     expect(classifyOpenClawVersionLockState('2026.3.23')).toBe('supported_not_target')
-    expect(classifyOpenClawVersionLockState('2026.3.24')).toBe('supported_target')
-    expect(classifyOpenClawVersionLockState('2026.3.25')).toBe('above_max')
+    expect(classifyOpenClawVersionLockState('2026.3.28')).toBe('supported_target')
+    // 高于 PINNED 的版本：因为 ALLOW_LATEST=true，视为已达标
+    expect(classifyOpenClawVersionLockState('2026.3.30')).toBe('supported_target')
+    expect(classifyOpenClawVersionLockState('2026.4.1')).toBe('supported_target')
+  })
+
+  it('treats versions above pinned as supported_not_target when dynamic target is higher', () => {
+    setDynamicTargetVersion('2026.4.5')
+    expect(classifyOpenClawVersionLockState('2026.3.28')).toBe('supported_not_target')
+    expect(classifyOpenClawVersionLockState('2026.4.1')).toBe('supported_not_target')
+    expect(classifyOpenClawVersionLockState('2026.4.5')).toBe('supported_target')
+    expect(classifyOpenClawVersionLockState('2026.4.6')).toBe('supported_target')
+  })
+
+  it('getEffectiveTargetVersion returns dynamic target when set', () => {
+    expect(getEffectiveTargetVersion()).toBe('2026.3.28')
+    setDynamicTargetVersion('2026.4.2')
+    expect(getEffectiveTargetVersion()).toBe('2026.4.2')
+    setDynamicTargetVersion(null)
+    expect(getEffectiveTargetVersion()).toBe('2026.3.28')
   })
 
   it('normalizes loose release tags before classifying', () => {
-    expect(classifyOpenClawVersionLockState('v2026.3.24-2')).toBe('supported_target')
+    expect(classifyOpenClawVersionLockState('v2026.3.28-2')).toBe('supported_target')
   })
 
   it('only auto-corrects sources that can be safely pinned in place', () => {
@@ -51,7 +76,7 @@ describe('openclaw version policy', () => {
     ).toMatchObject({
       enforcement: 'manual_block',
       targetAction: 'none',
-      targetVersion: '2026.3.24',
+      targetVersion: '2026.3.28',
       blocksContinue: true,
       canSelfHeal: false,
     })
@@ -67,7 +92,7 @@ describe('openclaw version policy', () => {
       policyState: 'below_min',
       enforcement: 'auto_correct',
       targetAction: 'upgrade',
-      targetVersion: '2026.3.24',
+      targetVersion: '2026.3.28',
       blocksContinue: true,
       canSelfHeal: true,
     })
@@ -81,7 +106,7 @@ describe('openclaw version policy', () => {
       policyState: 'supported_not_target',
       enforcement: 'optional_upgrade',
       targetAction: 'upgrade',
-      targetVersion: '2026.3.24',
+      targetVersion: '2026.3.28',
       blocksContinue: false,
       canSelfHeal: true,
     })
@@ -95,14 +120,14 @@ describe('openclaw version policy', () => {
       policyState: 'supported_not_target',
       enforcement: 'manual_block',
       targetAction: 'upgrade',
-      targetVersion: '2026.3.24',
+      targetVersion: '2026.3.28',
       blocksContinue: false,
       canSelfHeal: false,
     })
 
     expect(
       resolveOpenClawVersionEnforcement({
-        version: '2026.3.24',
+        version: '2026.3.28',
         installSource: 'npm-global',
       })
     ).toMatchObject({
@@ -114,32 +139,59 @@ describe('openclaw version policy', () => {
       canSelfHeal: false,
     })
 
+    // 高于 PINNED：不再阻断，允许继续（ALLOW_LATEST=true）
     expect(
       resolveOpenClawVersionEnforcement({
-        version: '2026.3.25',
+        version: '2026.3.30',
         installSource: 'npm-global',
       })
     ).toMatchObject({
-      policyState: 'above_max',
-      enforcement: 'auto_correct',
-      targetAction: 'downgrade',
-      targetVersion: '2026.3.24',
-      blocksContinue: true,
-      canSelfHeal: true,
+      policyState: 'supported_target',
+      enforcement: 'none',
+      targetAction: 'none',
+      blocksContinue: false,
     })
 
     expect(
       resolveOpenClawVersionEnforcement({
-        version: '2026.3.25',
+        version: '2026.3.30',
         installSource: 'custom',
       })
     ).toMatchObject({
-      policyState: 'above_max',
-      enforcement: 'manual_block',
-      targetAction: 'downgrade',
-      targetVersion: '2026.3.24',
-      blocksContinue: true,
-      canSelfHeal: false,
+      policyState: 'supported_target',
+      enforcement: 'none',
+      targetAction: 'none',
+      blocksContinue: false,
+    })
+  })
+
+  it('suggests upgrading to dynamic target when set', () => {
+    setDynamicTargetVersion('2026.4.5')
+
+    expect(
+      resolveOpenClawVersionEnforcement({
+        version: '2026.3.28',
+        installSource: 'npm-global',
+      })
+    ).toMatchObject({
+      policyState: 'supported_not_target',
+      enforcement: 'optional_upgrade',
+      targetAction: 'upgrade',
+      targetVersion: '2026.4.5',
+      blocksContinue: false,
+    })
+
+    // 已是最新
+    expect(
+      resolveOpenClawVersionEnforcement({
+        version: '2026.4.5',
+        installSource: 'npm-global',
+      })
+    ).toMatchObject({
+      policyState: 'supported_target',
+      enforcement: 'none',
+      targetAction: 'none',
+      blocksContinue: false,
     })
   })
 })

--- a/src/shared/desktop-window-policy.ts
+++ b/src/shared/desktop-window-policy.ts
@@ -73,7 +73,7 @@ const defaultWindowPolicy = desktopPolicy?.window || {
   defaultHeight: 600,
   minimumWidth: 640,
   minimumHeight: 480,
-  backgroundColor: '#09090b',
+  backgroundColor: '#ffffff',
   safeMargin: 32,
 }
 
@@ -86,7 +86,7 @@ export const DESKTOP_WINDOW_POLICY = Object.freeze({
   defaultHeight: toPositiveInteger(defaultWindowPolicy.defaultHeight, 600),
   minimumWidth: toPositiveInteger(defaultWindowPolicy.minimumWidth, 640),
   minimumHeight: toPositiveInteger(defaultWindowPolicy.minimumHeight, 480),
-  backgroundColor: String(defaultWindowPolicy.backgroundColor || '#09090b').trim() || '#09090b',
+  backgroundColor: String(defaultWindowPolicy.backgroundColor || '#ffffff').trim() || '#ffffff',
   safeMargin: toNonNegativeInteger(defaultWindowPolicy.safeMargin, 32),
   disableHardwareAccelerationWindowsReleasePrefixes: (
     defaultCompatibilityPolicy.disableHardwareAccelerationWindowsReleasePrefixes || ['6.1']

--- a/src/shared/gateway-runtime-reconcile-state.ts
+++ b/src/shared/gateway-runtime-reconcile-state.ts
@@ -8,6 +8,7 @@ export type OpenClawVersionBand =
   | 'openclaw_2026_3_14_to_2026_3_21'
   | 'openclaw_2026_3_22'
   | 'openclaw_2026_3_23_to_2026_3_24'
+  | 'openclaw_2026_3_25_to_2026_3_28'
   | 'unknown_future'
 
 export type UpgradeCompatibilityStatus =

--- a/src/shared/openclaw-version-adapter.ts
+++ b/src/shared/openclaw-version-adapter.ts
@@ -1,0 +1,438 @@
+/**
+ * OpenClaw 版本适配层
+ * 
+ * 设计目标：
+ * 1. 解耦版本号与功能支持，通过能力探测而非硬编码版本号
+ * 2. 支持动态功能发现，自动适应新版本
+ * 3. 提供优雅降级策略，未知版本不再完全限制功能
+ */
+
+// ==================== 类型定义 ====================
+
+export type VersionAdapterStatus = 
+  | 'supported'      // 完全支持
+  | 'degraded'       // 降级支持（部分功能受限）
+  | 'experimental'   // 实验性支持（未测试但尝试工作）
+  | 'unsupported'    // 不支持（已知不兼容）
+
+export interface VersionCapability {
+  /** 功能ID */
+  id: string
+  /** 功能名称 */
+  name: string
+  /** 是否支持 */
+  supported: boolean
+  /** 支持程度 */
+  level: 'full' | 'partial' | 'none'
+  /** 降级提示（如果不完全支持） */
+  degradeHint?: string
+  /** 探测命令（可选，用于动态探测） */
+  probeCommand?: string[]
+}
+
+export interface VersionAdapterConfig {
+  /** 版本号 */
+  version: string
+  /** 适配器状态 */
+  status: VersionAdapterStatus
+  /** 支持的功能列表 */
+  capabilities: VersionCapability[]
+  /** 已知问题 */
+  knownIssues?: string[]
+  /** 工作区配置变更 */
+  workspaceChanges?: Record<string, string>
+}
+
+export interface VersionProbeResult {
+  /** 探测是否成功 */
+  ok: boolean
+  /** 探测到的版本 */
+  version: string | null
+  /** 探测到的功能 */
+  capabilities: VersionCapability[]
+  /** 探测错误 */
+  error?: string
+}
+
+// ==================== 版本注册表 ====================
+
+/**
+ * 版本注册表
+ * 存储已知版本的适配配置
+ */
+class VersionRegistry {
+  private adapters = new Map<string, VersionAdapterConfig>()
+  private defaultAdapter: VersionAdapterConfig | null = null
+
+  constructor() {
+    this.registerDefaults()
+  }
+
+  private registerDefaults(): void {
+    // 注册已知版本的适配配置
+    this.register('2026.3.22', {
+      version: '2026.3.22',
+      status: 'supported',
+      capabilities: [
+        { id: 'env-alias', name: '环境变量别名', supported: false, level: 'none', degradeHint: '3.22已移除legacy env alias' },
+        { id: 'plugin-path', name: '插件路径解析', supported: true, level: 'full' },
+        { id: 'clawhub', name: 'ClawHub解析', supported: true, level: 'full' },
+        { id: 'doctor-fix', name: 'Doctor修复', supported: true, level: 'full' },
+        { id: 'gateway-control', name: '网关控制', supported: true, level: 'full' },
+        { id: 'auth-registry', name: '认证注册表', supported: true, level: 'full' },
+      ],
+      workspaceChanges: {
+        'env-alias': 'OPENCLAW_*替代CLAWDBOT_*/MOLTBOT_*',
+        'plugin-path': 'bundled plugin路径收敛',
+      },
+    })
+
+    this.register('2026.3.24', {
+      version: '2026.3.24',
+      status: 'supported',
+      capabilities: [
+        { id: 'env-alias', name: '环境变量别名', supported: false, level: 'none', degradeHint: '3.22+已移除legacy env alias' },
+        { id: 'plugin-path', name: '插件路径解析', supported: true, level: 'full' },
+        { id: 'clawhub', name: 'ClawHub解析', supported: true, level: 'full' },
+        { id: 'doctor-fix', name: 'Doctor修复', supported: true, level: 'full' },
+        { id: 'gateway-control', name: '网关控制', supported: true, level: 'full' },
+        { id: 'auth-registry', name: '认证注册表', supported: true, level: 'full' },
+      ],
+    })
+
+    this.register('2026.3.28', {
+      version: '2026.3.28',
+      status: 'supported',
+      capabilities: [
+        { id: 'env-alias', name: '环境变量别名', supported: false, level: 'none', degradeHint: '3.22+已移除legacy env alias' },
+        { id: 'plugin-path', name: '插件路径解析', supported: true, level: 'full' },
+        { id: 'clawhub', name: 'ClawHub解析', supported: true, level: 'full' },
+        { id: 'doctor-fix', name: 'Doctor修复', supported: true, level: 'full' },
+        { id: 'gateway-control', name: '网关控制', supported: true, level: 'full' },
+        { id: 'auth-registry', name: '认证注册表', supported: true, level: 'full' },
+      ],
+    })
+
+    // 默认适配器：用于未知版本
+    this.defaultAdapter = {
+      version: 'unknown',
+      status: 'experimental',
+      capabilities: [
+        { id: 'env-alias', name: '环境变量别名', supported: true, level: 'partial', degradeHint: '自动探测中' },
+        { id: 'plugin-path', name: '插件路径解析', supported: true, level: 'partial', degradeHint: '自动探测中' },
+        { id: 'clawhub', name: 'ClawHub解析', supported: true, level: 'partial', degradeHint: '自动探测中' },
+        { id: 'doctor-fix', name: 'Doctor修复', supported: true, level: 'partial', degradeHint: '自动探测中' },
+        { id: 'gateway-control', name: '网关控制', supported: true, level: 'partial', degradeHint: '自动探测中' },
+        { id: 'auth-registry', name: '认证注册表', supported: true, level: 'partial', degradeHint: '自动探测中' },
+      ],
+      knownIssues: ['版本未验证，功能可能受限'],
+    }
+  }
+
+  register(version: string, config: VersionAdapterConfig): void {
+    this.adapters.set(this.normalizeVersion(version), config)
+  }
+
+  get(version: string): VersionAdapterConfig | null {
+    const normalized = this.normalizeVersion(version)
+    const config = this.adapters.get(normalized)
+    if (config) return config
+    
+    // 返回默认适配器时，使用传入的版本号
+    if (this.defaultAdapter) {
+      return {
+        ...this.defaultAdapter,
+        version: normalized,
+      }
+    }
+    return null
+  }
+
+  has(version: string): boolean {
+    return this.adapters.has(this.normalizeVersion(version))
+  }
+
+  private normalizeVersion(version: string): string {
+    return String(version || '').trim().replace(/^v/i, '')
+  }
+}
+
+// ==================== 版本适配器 ====================
+
+/**
+ * 版本适配器
+ * 根据版本提供统一的功能访问接口
+ */
+export class VersionAdapter {
+  private registry: VersionRegistry
+  private config: VersionAdapterConfig
+  private probeCache = new Map<string, VersionProbeResult>()
+
+  constructor(version: string, registry?: VersionRegistry) {
+    this.registry = registry || new VersionRegistry()
+    this.config = this.registry.get(version) || this.createFallbackConfig(version)
+  }
+
+  private createFallbackConfig(version: string): VersionAdapterConfig {
+    return {
+      version,
+      status: 'experimental',
+      capabilities: [],
+      knownIssues: [`版本 ${version} 未在注册表中找到`],
+    }
+  }
+
+  /**
+   * 获取适配器状态
+   */
+  getStatus(): VersionAdapterStatus {
+    return this.config.status
+  }
+
+  /**
+   * 获取版本号
+   */
+  getVersion(): string {
+    return this.config.version
+  }
+
+  /**
+   * 检查功能是否支持
+   */
+  isCapabilitySupported(capabilityId: string): boolean {
+    const capability = this.config.capabilities.find(c => c.id === capabilityId)
+    return capability?.supported ?? false
+  }
+
+  /**
+   * 获取功能降级提示
+   */
+  getCapabilityDegradeHint(capabilityId: string): string | null {
+    const capability = this.config.capabilities.find(c => c.id === capabilityId)
+    return capability?.degradeHint ?? null
+  }
+
+  /**
+   * 获取所有功能
+   */
+  getCapabilities(): VersionCapability[] {
+    return [...this.config.capabilities]
+  }
+
+  /**
+   * 获取已知问题
+   */
+  getKnownIssues(): string[] {
+    return this.config.knownIssues || []
+  }
+
+  /**
+   * 获取工作区配置变更
+   */
+  getWorkspaceChanges(): Record<string, string> {
+    return this.config.workspaceChanges || {}
+  }
+
+  /**
+   * 动态探测功能支持
+   * 当静态配置不完整时，尝试通过运行命令探测
+   */
+  async probeCapability(
+    capabilityId: string,
+    runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+  ): Promise<VersionProbeResult> {
+    // 检查缓存
+    if (this.probeCache.has(capabilityId)) {
+      return this.probeCache.get(capabilityId)!
+    }
+
+    const capability = this.config.capabilities.find(c => c.id === capabilityId)
+    if (!capability?.probeCommand) {
+      return { ok: false, version: this.config.version, capabilities: [], error: 'No probe command configured' }
+    }
+
+    try {
+      const result = await runCommand(capability.probeCommand)
+      const probeResult: VersionProbeResult = {
+        ok: result.ok,
+        version: this.config.version,
+        capabilities: [{
+          ...capability,
+          supported: result.ok,
+          level: result.ok ? 'full' : 'none',
+        }],
+      }
+      this.probeCache.set(capabilityId, probeResult)
+      return probeResult
+    } catch (error) {
+      const probeResult: VersionProbeResult = {
+        ok: false,
+        version: this.config.version,
+        capabilities: [],
+        error: error instanceof Error ? error.message : String(error),
+      }
+      this.probeCache.set(capabilityId, probeResult)
+      return probeResult
+    }
+  }
+
+  /**
+   * 批量探测功能
+   */
+  async probeCapabilities(
+    capabilityIds: string[],
+    runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+  ): Promise<Map<string, VersionProbeResult>> {
+    const results = new Map<string, VersionProbeResult>()
+    for (const id of capabilityIds) {
+      results.set(id, await this.probeCapability(id, runCommand))
+    }
+    return results
+  }
+
+  /**
+   * 更新配置（用于动态发现）
+   */
+  updateConfig(updates: Partial<VersionAdapterConfig>): void {
+    this.config = { ...this.config, ...updates }
+  }
+
+  /**
+   * 合并探测结果到配置
+   */
+  mergeProbeResults(probeResults: Map<string, VersionProbeResult>): void {
+    const updatedCapabilities = this.config.capabilities.map(cap => {
+      const probe = probeResults.get(cap.id)
+      if (probe?.ok) {
+        const probedCap = probe.capabilities[0]
+        if (probedCap) {
+          return { ...cap, supported: probedCap.supported, level: probedCap.level }
+        }
+      }
+      return cap
+    })
+
+    this.config = {
+      ...this.config,
+      capabilities: updatedCapabilities,
+    }
+  }
+}
+
+// ==================== 版本探测器 ====================
+
+/**
+ * 版本探测器
+ * 负责探测OpenClaw版本和功能
+ */
+export class VersionProbe {
+  /**
+   * 探测OpenClaw版本
+   */
+  static async detectVersion(
+    runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+  ): Promise<VersionProbeResult> {
+    try {
+      const result = await runCommand(['--version'])
+      if (!result.ok) {
+        return { ok: false, version: null, capabilities: [], error: result.stderr }
+      }
+
+      const version = this.parseVersion(result.stdout)
+      return { ok: true, version, capabilities: [] }
+    } catch (error) {
+      return {
+        ok: false,
+        version: null,
+        capabilities: [],
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  /**
+   * 解析版本号
+   */
+  private static parseVersion(output: string): string | null {
+    const lines = output.split('\n')
+    for (const line of lines) {
+      const match = line.match(/(\d{4}\.\d+\.\d+)/)
+      if (match) {
+        return match[1]
+      }
+    }
+    return null
+  }
+
+  /**
+   * 探测功能支持
+   */
+  static async detectCapabilities(
+    runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+  ): Promise<VersionCapability[]> {
+    const capabilities: VersionCapability[] = []
+
+    // 探测help命令
+    const helpResult = await runCommand(['--help'])
+    if (helpResult.ok) {
+      // 分析help输出，探测支持的命令
+      const helpText = helpResult.stdout + helpResult.stderr
+      
+      // 检查常见命令
+      const commands = [
+        { id: 'gateway', name: '网关控制', keywords: ['gateway', 'start', 'stop', 'restart'] },
+        { id: 'models', name: '模型管理', keywords: ['models', 'list', 'status', 'auth'] },
+        { id: 'plugins', name: '插件管理', keywords: ['plugins', 'install', 'uninstall'] },
+        { id: 'doctor', name: '诊断修复', keywords: ['doctor', 'fix'] },
+        { id: 'onboard', name: '配置向导', keywords: ['onboard'] },
+      ]
+
+      for (const cmd of commands) {
+        const supported = cmd.keywords.some(kw => helpText.toLowerCase().includes(kw))
+        capabilities.push({
+          id: cmd.id,
+          name: cmd.name,
+          supported,
+          level: supported ? 'full' : 'none',
+        })
+      }
+    }
+
+    return capabilities
+  }
+}
+
+// ==================== 工厂函数 ====================
+
+/**
+ * 创建版本适配器
+ */
+export function createVersionAdapter(
+  version: string,
+  registry?: VersionRegistry
+): VersionAdapter {
+  return new VersionAdapter(version, registry)
+}
+
+/**
+ * 创建版本适配器（异步，带探测）
+ */
+export async function createVersionAdapterWithProbe(
+  runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>,
+  registry?: VersionRegistry
+): Promise<VersionAdapter> {
+  const probeResult = await VersionProbe.detectVersion(runCommand)
+  if (!probeResult.ok || !probeResult.version) {
+    return createVersionAdapter('unknown', registry)
+  }
+
+  const adapter = createVersionAdapter(probeResult.version, registry)
+  
+  // 探测功能
+  const capabilities = await VersionProbe.detectCapabilities(runCommand)
+  if (capabilities.length > 0) {
+    adapter.updateConfig({ capabilities })
+  }
+
+  return adapter
+}

--- a/src/shared/openclaw-version-compat.ts
+++ b/src/shared/openclaw-version-compat.ts
@@ -1,0 +1,284 @@
+/**
+ * OpenClaw 版本兼容性层
+ * 
+ * 提供新版本适配器与现有代码的兼容接口
+ * 支持渐进式迁移，新旧系统可以共存
+ */
+
+import {
+  type VersionAdapter,
+  type VersionAdapterStatus,
+  type VersionCapability,
+  createVersionAdapter,
+  createVersionAdapterWithProbe,
+} from './openclaw-version-adapter'
+
+// ==================== 兼容类型定义 ====================
+
+/**
+ * 兼容旧系统的版本策略状态
+ */
+export type LegacyVersionPolicyState =
+  | 'below_min'
+  | 'supported_not_target'
+  | 'supported_target'
+  | 'above_max'
+
+/**
+ * 兼容旧系统的版本执行策略
+ */
+export type LegacyVersionEnforcement =
+  | 'none'
+  | 'optional_upgrade'
+  | 'auto_correct'
+  | 'manual_block'
+
+/**
+ * 兼容旧系统的版本band
+ */
+export type LegacyVersionBand =
+  | 'unknown'
+  | 'pre_2026_3_7'
+  | 'openclaw_2026_3_7_to_2026_3_11'
+  | 'openclaw_2026_3_12_to_2026_3_13'
+  | 'openclaw_2026_3_14_to_2026_3_21'
+  | 'openclaw_2026_3_22'
+  | 'openclaw_2026_3_23_to_2026_3_24'
+  | 'unknown_future'
+
+// ==================== 兼容接口 ====================
+
+/**
+ * 版本兼容性结果
+ */
+export interface VersionCompatResult {
+  /** 版本号 */
+  version: string | null
+  /** 适配器状态 */
+  adapterStatus: VersionAdapterStatus
+  /** 是否进入保守模式 */
+  conservativeMode: boolean
+  /** 警告代码 */
+  warningCodes: string[]
+  /** 摘要信息 */
+  summary: string
+  /** 兼容的旧版band */
+  legacyBand: LegacyVersionBand
+  /** 兼容的旧版策略状态 */
+  legacyPolicyState: LegacyVersionPolicyState
+  /** 兼容的旧版执行策略 */
+  legacyEnforcement: LegacyVersionEnforcement
+  /** 功能支持情况 */
+  capabilities: VersionCapability[]
+}
+
+// ==================== 版本解析工具 ====================
+
+function parseVersionCore(version: string | null | undefined): string {
+  return String(version || '').trim().replace(/^v/i, '').split('-')[0].trim()
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number)
+  const rightParts = right.split('.').map(Number)
+  
+  for (let i = 0; i < 3; i++) {
+    const l = leftParts[i] || 0
+    const r = rightParts[i] || 0
+    if (l !== r) return l - r
+  }
+  return 0
+}
+
+// ==================== 版本band检测（兼容旧版） ====================
+
+function detectLegacyVersionBand(version: string | null | undefined): LegacyVersionBand {
+  const normalized = parseVersionCore(version)
+  if (!normalized) return 'unknown'
+
+  if (compareVersions(normalized, '2026.3.7') < 0) return 'pre_2026_3_7'
+  if (compareVersions(normalized, '2026.3.11') <= 0) return 'openclaw_2026_3_7_to_2026_3_11'
+  if (compareVersions(normalized, '2026.3.13') <= 0) return 'openclaw_2026_3_12_to_2026_3_13'
+  if (compareVersions(normalized, '2026.3.21') <= 0) return 'openclaw_2026_3_14_to_2026_3_21'
+  if (compareVersions(normalized, '2026.3.22') === 0) return 'openclaw_2026_3_22'
+  if (compareVersions(normalized, '2026.3.24') <= 0) return 'openclaw_2026_3_23_to_2026_3_24'
+  
+  // 新版本：不再是unknown_future，而是根据实际能力判断
+  return 'unknown_future'
+}
+
+// ==================== 版本策略状态检测（兼容旧版） ====================
+
+function detectLegacyPolicyState(version: string | null | undefined): LegacyVersionPolicyState {
+  const normalized = parseVersionCore(version)
+  if (!normalized) return 'above_max'
+
+  // 新策略：只要版本 >= 2026.3.22 就认为是支持的
+  if (compareVersions(normalized, '2026.3.22') < 0) {
+    return 'below_min'
+  }
+
+  // 检查是否是目标版本
+  if (normalized === '2026.3.24') {
+    return 'supported_target'
+  }
+
+  return 'supported_not_target'
+}
+
+// ==================== 版本执行策略检测（兼容旧版） ====================
+
+function detectLegacyEnforcement(
+  policyState: LegacyVersionPolicyState,
+  canCorrect: boolean
+): LegacyVersionEnforcement {
+  switch (policyState) {
+    case 'supported_target':
+      return 'none'
+    case 'supported_not_target':
+      return canCorrect ? 'optional_upgrade' : 'manual_block'
+    case 'below_min':
+      return canCorrect ? 'auto_correct' : 'manual_block'
+    case 'above_max':
+    default:
+      // 新策略：对于高于最大版本的情况，不再强制阻止
+      return canCorrect ? 'optional_upgrade' : 'none'
+  }
+}
+
+// ==================== 主要导出函数 ====================
+
+/**
+ * 评估版本兼容性（新版本适配器）
+ */
+export function assessVersionCompatibility(
+  version: string | null | undefined,
+  adapter: VersionAdapter | null
+): VersionCompatResult {
+  const normalizedVersion = parseVersionCore(version)
+  
+  // 获取适配器状态
+  const adapterStatus = adapter?.getStatus() ?? 'experimental'
+  
+  // 判断是否进入保守模式
+  // 新策略：只有在适配器明确标记为unsupported时才进入保守模式
+  const conservativeMode = adapterStatus === 'unsupported'
+  
+  // 获取警告代码
+  const warningCodes: string[] = []
+  if (adapterStatus === 'experimental') {
+    warningCodes.push('version_experimental')
+  }
+  if (adapterStatus === 'degraded') {
+    warningCodes.push('version_degraded')
+  }
+  
+  // 获取功能支持情况
+  const capabilities = adapter?.getCapabilities() ?? []
+  
+  // 构建摘要
+  const summary = buildCompatibilitySummary(
+    normalizedVersion,
+    adapterStatus,
+    conservativeMode,
+    capabilities
+  )
+  
+  // 兼容旧版接口
+  const legacyBand = detectLegacyVersionBand(normalizedVersion)
+  const legacyPolicyState = detectLegacyPolicyState(normalizedVersion)
+  const legacyEnforcement = detectLegacyEnforcement(legacyPolicyState, true)
+  
+  return {
+    version: normalizedVersion,
+    adapterStatus,
+    conservativeMode,
+    warningCodes,
+    summary,
+    legacyBand,
+    legacyPolicyState,
+    legacyEnforcement,
+    capabilities,
+  }
+}
+
+/**
+ * 构建兼容性摘要
+ */
+function buildCompatibilitySummary(
+  version: string | null,
+  adapterStatus: VersionAdapterStatus,
+  conservativeMode: boolean,
+  capabilities: VersionCapability[]
+): string {
+  if (!version) {
+    return 'OpenClaw 版本无法解析。'
+  }
+
+  const statusText = {
+    supported: '完全支持',
+    degraded: '降级支持',
+    experimental: '实验性支持',
+    unsupported: '不支持',
+  }[adapterStatus]
+
+  const supportedCount = capabilities.filter(c => c.supported).length
+  const totalCount = capabilities.length
+
+  if (conservativeMode) {
+    return `OpenClaw ${version} 未通过兼容性检查（${statusText}），已进入保守模式。`
+  }
+
+  if (adapterStatus === 'experimental') {
+    return `OpenClaw ${version} 为新版本，Qclaw 将尝试适配（${supportedCount}/${totalCount} 功能已确认支持）。`
+  }
+
+  if (adapterStatus === 'degraded') {
+    const degradedCapabilities = capabilities
+      .filter(c => c.level === 'partial' || !c.supported)
+      .map(c => c.name)
+      .join('、')
+    return `OpenClaw ${version} 部分功能受限（${statusText}）：${degradedCapabilities}。`
+  }
+
+  return `OpenClaw ${version} 已确认兼容（${statusText}）。`
+}
+
+/**
+ * 创建版本适配器并评估兼容性（异步）
+ */
+export async function assessVersionCompatibilityWithProbe(
+  runCommand: (args: string[]) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+): Promise<VersionCompatResult> {
+  const adapter = await createVersionAdapterWithProbe(runCommand)
+  return assessVersionCompatibility(adapter.getVersion(), adapter)
+}
+
+/**
+ * 检查功能是否支持（带降级提示）
+ */
+export function checkCapabilityWithHint(
+  adapter: VersionAdapter | null,
+  capabilityId: string
+): { supported: boolean; hint: string | null } {
+  if (!adapter) {
+    return { supported: true, hint: '版本适配器未初始化' }
+  }
+
+  const supported = adapter.isCapabilitySupported(capabilityId)
+  const hint = adapter.getCapabilityDegradeHint(capabilityId)
+
+  return { supported, hint }
+}
+
+/**
+ * 获取功能降级提示
+ */
+export function getCapabilityDegradeMessage(
+  adapter: VersionAdapter | null,
+  capabilityId: string
+): string | null {
+  const { supported, hint } = checkCapabilityWithHint(adapter, capabilityId)
+  if (supported) return null
+  return hint ?? `功能 ${capabilityId} 在当前版本不可用`
+}

--- a/src/shared/openclaw-version-policy.ts
+++ b/src/shared/openclaw-version-policy.ts
@@ -1,9 +1,56 @@
 import type { OpenClawInstallSource } from './openclaw-phase1'
 import { compareLooseVersions } from './openclaw-phase1'
+import { type VersionAdapter, createVersionAdapter } from './openclaw-version-adapter'
 
 export const MIN_SUPPORTED_OPENCLAW_VERSION = '2026.3.22'
-export const MAX_SUPPORTED_OPENCLAW_VERSION = '2026.3.24'
-export const PINNED_OPENCLAW_VERSION = '2026.3.24'
+/** @deprecated 不再使用硬编码上限，保留仅为兼容旧测试 */
+export const MAX_SUPPORTED_OPENCLAW_VERSION = '2026.3.28'
+/** 默认锁定版本，当未查询到 npm latest 时的回退值 */
+export const PINNED_OPENCLAW_VERSION = '2026.3.28'
+
+/**
+ * 允许升级到最新版本的标志
+ * 设为 true 后，高于 MAX_SUPPORTED 的版本不再被阻断
+ */
+export const ALLOW_LATEST_OPENCLAW_VERSION = true
+
+/**
+ * 动态目标版本（由 npm latest 查询结果填充）
+ * 如果为 null 则使用 PINNED_OPENCLAW_VERSION
+ */
+let dynamicTargetVersion: string | null = null
+
+/**
+ * 设置动态目标版本（来自 npm registry latest 查询）
+ */
+export function setDynamicTargetVersion(version: string | null): void {
+  dynamicTargetVersion = version
+}
+
+/**
+ * 获取当前升级目标版本
+ * 优先使用动态查询到的最新版本，否则回退到 PINNED_OPENCLAW_VERSION
+ */
+export function getEffectiveTargetVersion(): string {
+  return dynamicTargetVersion || PINNED_OPENCLAW_VERSION
+}
+
+// 版本适配器实例（可选，用于新版本适配）
+let versionAdapter: VersionAdapter | null = null
+
+/**
+ * 设置版本适配器
+ */
+export function setVersionAdapter(adapter: VersionAdapter | null): void {
+  versionAdapter = adapter
+}
+
+/**
+ * 获取版本适配器
+ */
+export function getVersionAdapter(): VersionAdapter | null {
+  return versionAdapter
+}
 
 export type OpenClawVersionPolicyState =
   | 'below_min'
@@ -65,17 +112,54 @@ export function classifyOpenClawVersionLockState(
   version: string | null | undefined
 ): OpenClawVersionPolicyState {
   const normalizedVersion = normalizeOpenClawPolicyVersion(version) || '0.0.0'
+  const effectiveTarget = getEffectiveTargetVersion()
 
+  // 如果设置了版本适配器，使用适配器的判断
+  if (versionAdapter) {
+    const adapterStatus = versionAdapter.getStatus()
+    
+    // 如果适配器标记为supported或degraded，认为是支持的
+    if (adapterStatus === 'supported' || adapterStatus === 'degraded') {
+      // 检查是否是目标版本（或已是最新）
+      if (normalizedVersion === effectiveTarget ||
+          compareLooseVersions(normalizedVersion, effectiveTarget) >= 0) {
+        return 'supported_target'
+      }
+      return 'supported_not_target'
+    }
+    
+    // 如果是experimental，允许继续但标记为非目标
+    if (adapterStatus === 'experimental') {
+      // 检查是否已达目标版本
+      if (compareLooseVersions(normalizedVersion, effectiveTarget) >= 0) {
+        return 'supported_target'
+      }
+      return 'supported_not_target'
+    }
+    
+    // 如果是unsupported，检查是否低于最小版本
+    if (compareLooseVersions(normalizedVersion, MIN_SUPPORTED_OPENCLAW_VERSION) < 0) {
+      return 'below_min'
+    }
+    return 'above_max'
+  }
+
+  // 低于最小支持版本
   if (compareLooseVersions(normalizedVersion, MIN_SUPPORTED_OPENCLAW_VERSION) < 0) {
     return 'below_min'
   }
-  if (compareLooseVersions(normalizedVersion, MAX_SUPPORTED_OPENCLAW_VERSION) > 0) {
-    return 'above_max'
-  }
-  if (compareLooseVersions(normalizedVersion, PINNED_OPENCLAW_VERSION) === 0) {
+
+  // 已达到或超过目标版本 → 视为已达标
+  if (compareLooseVersions(normalizedVersion, effectiveTarget) >= 0) {
     return 'supported_target'
   }
-  return 'supported_not_target'
+
+  // 在支持范围内但未达目标
+  if (ALLOW_LATEST_OPENCLAW_VERSION || compareLooseVersions(normalizedVersion, MAX_SUPPORTED_OPENCLAW_VERSION) <= 0) {
+    return 'supported_not_target'
+  }
+
+  return 'above_max'
 }
 
 export function supportsPinnedOpenClawCorrection(
@@ -121,13 +205,33 @@ export function resolveOpenClawVersionEnforcement(input: {
   candidatePaths?: OpenClawInstallCandidatePaths | null
 }): OpenClawVersionEnforcementResult {
   const normalizedVersion = normalizeOpenClawPolicyVersion(input.version)
+  const effectiveTarget = getEffectiveTargetVersion()
+
   if (!isStrictOpenClawPolicyVersion(normalizedVersion)) {
+    // 如果设置了版本适配器，使用适配器的判断
+    if (versionAdapter) {
+      const adapterStatus = versionAdapter.getStatus()
+      
+      // experimental 或 degraded 状态允许继续
+      if (adapterStatus === 'experimental' || adapterStatus === 'degraded') {
+        return {
+          normalizedVersion,
+          policyState: 'supported_not_target',
+          enforcement: 'none',
+          targetAction: 'none',
+          targetVersion: null,
+          blocksContinue: false,
+          canSelfHeal: false,
+        }
+      }
+    }
+    
     return {
       normalizedVersion,
       policyState: 'above_max',
       enforcement: 'manual_block',
       targetAction: 'none',
-      targetVersion: PINNED_OPENCLAW_VERSION,
+      targetVersion: effectiveTarget,
       blocksContinue: true,
       canSelfHeal: false,
     }
@@ -152,7 +256,7 @@ export function resolveOpenClawVersionEnforcement(input: {
         policyState,
         enforcement: canCorrect ? 'optional_upgrade' : 'manual_block',
         targetAction: 'upgrade',
-        targetVersion: PINNED_OPENCLAW_VERSION,
+        targetVersion: effectiveTarget,
         blocksContinue: false,
         canSelfHeal: canCorrect,
       }
@@ -162,18 +266,31 @@ export function resolveOpenClawVersionEnforcement(input: {
         policyState,
         enforcement: canCorrect ? 'auto_correct' : 'manual_block',
         targetAction: 'upgrade',
-        targetVersion: PINNED_OPENCLAW_VERSION,
+        targetVersion: effectiveTarget,
         blocksContinue: true,
         canSelfHeal: canCorrect,
       }
     case 'above_max':
     default:
+      // 新策略：ALLOW_LATEST_OPENCLAW_VERSION 或适配器激活时，不再强制降级
+      if (ALLOW_LATEST_OPENCLAW_VERSION || (versionAdapter && versionAdapter.getStatus() !== 'unsupported')) {
+        return {
+          normalizedVersion,
+          policyState: 'supported_not_target',
+          enforcement: canCorrect ? 'optional_upgrade' : 'none',
+          targetAction: 'upgrade',
+          targetVersion: effectiveTarget,
+          blocksContinue: false,
+          canSelfHeal: canCorrect,
+        }
+      }
+      
       return {
         normalizedVersion,
         policyState,
         enforcement: canCorrect ? 'auto_correct' : 'manual_block',
         targetAction: 'downgrade',
-        targetVersion: PINNED_OPENCLAW_VERSION,
+        targetVersion: effectiveTarget,
         blocksContinue: true,
         canSelfHeal: canCorrect,
       }


### PR DESCRIPTION
## 变更说明

本次 PR 主要包含两部分增强功能：

1. **开发体验优化（后台运行模式）**：
   - 扩展了 `scripts/qclaw-start.sh`，新增 `qclaw bg` 命令以支持将开发服务器放到后台静默运行。
   - 在 macOS 下支持自动最小化/隐藏终端窗口，解决开发模式下终端常驻的问题。
   - 配套提供了 `qclaw status`（状态查询）、`qclaw stop`（停止服务）和 `qclaw log`（实时查看日志）等进程管理命令。
   - 更新了 `.gitignore`，防止误提交新的 `.qclaw-dev.pid` 文件。

2. **OpenClaw 升级与版本策略重构（动态版本支持）**：
   - 移除了原有的硬编码版本限制，使 Qclaw 能够更好地支持和适配不断发布的 OpenClaw 新版本。
   - 新增了 `openclaw-version-adapter.ts`，为升级流程引入了动态版本适配和校验能力。
   - 优化了 `OpenClawUpgradeDialog.tsx` 及底层的升级服务 (`openclaw-upgrade-service.ts`)，现在可以更加平滑且安全地进行动态目标版本的升级。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [x] 重构 / 优化
- [ ] 依赖更新
- [ ] CI / 构建配置
- [ ] 文档

## 影响范围

- [x] Electron 主进程 (`electron/main/`)
- [ ] Preload / IPC 桥接 (`electron/preload/`)
- [x] React 渲染层 (`src/`)
- [ ] 构建与打包配置
- [ ] 文档

## 测试

- [x] 已通过 `npm run typecheck`
- [x] 已通过 `npm test`
- [x] 已在本地运行 `npm run dev` 验证功能

## 补充说明

- 关于 `qclaw bg`，目前实现了基于 PID 文件的轻量级进程管理，并在 macOS 的 Terminal 和 iTerm2 测试过窗口自动隐藏。
- 升级策略的改动兼容历史的降级逻辑和错误回退处理，相关核心逻辑均补充/修改了测试用例（位于 `__tests__`）。
