### PR TITLE
Refresh MiniMax provider metadata for MiniMax-M3 and MiniMax-M2.7 with global and China variants

### DIFF
--- a/install-web-v1.manifest.json
+++ b/install-web-v1.manifest.json
@@ -131,7 +131,7 @@
       "links": [
         {
           "label": "MiniMax 官网",
-          "url": "https://platform.minimaxi.com"
+          "url": "https://platform.minimax.io"
         }
       ]
     },

--- a/src/lib/__tests__/openclaw-provider-registry.test.ts
+++ b/src/lib/__tests__/openclaw-provider-registry.test.ts
@@ -79,6 +79,21 @@ describe('openclaw-provider-registry', () => {
     expect(getProviderMetadata('ollama')?.description).toBe('本地 LLM 环境')
   })
 
+  it('refreshes the minimax provider metadata for the current global and China variants', () => {
+    const minimax = getProviderMetadata('minimax')
+    expect(minimax?.region).toBe('global')
+    expect(minimax?.signupUrl).toBe('https://platform.minimax.io/')
+    expect(minimax?.description).toBe('MiniMax M3, MiniMax M2.7')
+    expect(minimax?.methods).toEqual([
+      { authChoice: 'minimax-api-key', envKey: 'MINIMAX_API_KEY' },
+      { authChoice: 'minimax-api-key-cn', envKey: 'MINIMAX_API_KEY' },
+    ])
+    expect(resolveKnownProviderIdForAuthChoice('minimax-api-key')).toBe('minimax')
+    expect(resolveKnownProviderIdForAuthChoice('minimax-api-key-cn')).toBe('minimax')
+    expect(resolveProviderMethodEnvKey('minimax', 'minimax-api-key')).toBe('MINIMAX_API_KEY')
+    expect(resolveProviderMethodEnvKey('minimax', 'minimax-api-key-cn')).toBe('MINIMAX_API_KEY')
+  })
+
   it('builds dashboard catalog entries from the centralized registry', () => {
     const catalog = getKnownProviderCatalog()
     expect(catalog.find((provider) => provider.id === 'openai')).toEqual({

--- a/src/lib/openclaw-provider-registry.ts
+++ b/src/lib/openclaw-provider-registry.ts
@@ -70,11 +70,14 @@ const KNOWN_PROVIDER_METADATA: ProviderMetadata[] = [
     id: 'minimax',
     name: 'MiniMax',
     logo: '⚡',
-    region: 'china',
-    signupUrl: 'https://api.minimax.chat/',
-    description: 'MiniMax M2.5',
+    region: 'global',
+    signupUrl: 'https://platform.minimax.io/',
+    description: 'MiniMax M3, MiniMax M2.7',
     primaryEnvKey: 'MINIMAX_API_KEY',
-    methods: [{ authChoice: 'minimax-api-key-cn', envKey: 'MINIMAX_API_KEY' }],
+    methods: [
+      { authChoice: 'minimax-api-key', envKey: 'MINIMAX_API_KEY' },
+      { authChoice: 'minimax-api-key-cn', envKey: 'MINIMAX_API_KEY' },
+    ],
   },
   {
     id: 'moonshot',


### PR DESCRIPTION
Reason: Refresh the stale MiniMax provider metadata for the current MiniMax-M3 and MiniMax-M2.7 models and both the global and China endpoint/auth variants.

Changes:
- `src/lib/openclaw-provider-registry.ts`: update the `minimax` provider entry so it is no longer marked China-only — switch `region` to `global`, point `signupUrl` at the current global platform (`https://platform.minimax.io/`), refresh `description` to the current models (`MiniMax M3, MiniMax M2.7`), and expose both `minimax-api-key` (global) and `minimax-api-key-cn` (China) auth methods sharing `MINIMAX_API_KEY`.
- `install-web-v1.manifest.json`: point the MiniMax provider's official site link at the global platform root.
- `src/lib/__tests__/openclaw-provider-registry.test.ts`: add a regression test asserting the refreshed region, signup URL, description, auth methods, and auth-choice/env-key resolution for both variants.

Checks run locally:
- `vitest run` for the provider-registry, install-web-v1 policy, auth-registry, model-oauth, minimax legacy alias repair, and provider-aliases tests — all passing.
- `tsc --noEmit -p tsconfig.json` — no type errors.
